### PR TITLE
Add msbuild task

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
                 "properties": {
                     "operation": {
                         "type": "string",
-                        "description": "The pqtest operation to run"
+                        "description": "The operation to run"
                     },
                     "additionalArgs": {
                         "type": "array",

--- a/src/common/OperationType.ts
+++ b/src/common/OperationType.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+export type OperationType = BuildOperationType | PQTestOperationType;
+
+export type BuildOperationType = "msbuild";
+
+export type PQTestOperationType =
+    | "delete-credential"
+    | "info"
+    | "list-credential"
+    | "credential-template"
+    | "set-credential"
+    | "refresh-credential"
+    | "run-test"
+    | "test-connection"
+    | string;

--- a/src/common/PQTestService.ts
+++ b/src/common/PQTestService.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root of this projects source tree.
  */
 
-import * as vscode from "vscode";
+import { PQTestTask } from "./PowerQueryTask";
 
 export interface GenericResult {
     readonly Status: "Success" | "Failure";
@@ -15,31 +15,6 @@ export interface GenericResult {
 }
 
 export type AuthenticationKind = "Anonymous" | "Key" | "Aad" | "OAuth2" | "UsernamePassword" | "Windows";
-export type OperationType =
-    | "delete-credential"
-    | "info"
-    | "list-credential"
-    | "credential-template"
-    | "set-credential"
-    | "refresh-credential"
-    | "run-test"
-    | "test-connection"
-    | string;
-
-export interface PQTestTaskBase {
-    readonly operation: OperationType;
-    readonly additionalArgs?: string[];
-    readonly pathToConnector?: string;
-    readonly pathToQueryFile?: string;
-    readonly stdinStr?: string;
-}
-
-// Properties that need to be persisted as part of the task definition should be
-// included in the taskDefinitions section of package.json.
-// TODO: Are we using "Connector" or "Extension" terminology?
-export interface PQTestTaskDefinition extends PQTestTaskBase, vscode.TaskDefinition {
-    readonly label?: string;
-}
 
 export interface IPQTestService {
     readonly pqTestReady: boolean;
@@ -63,24 +38,24 @@ export interface IPQTestService {
 
 const CommonArgs: string[] = ["--prettyPrint"];
 
-export function buildPqTestArgs(pqTestTaskBase: PQTestTaskBase): string[] {
+export function buildPqTestArgs(pqTestTask: PQTestTask): string[] {
     const args: string[] = CommonArgs.slice();
 
-    if (pqTestTaskBase.additionalArgs) {
-        args.push(...pqTestTaskBase.additionalArgs);
+    if (pqTestTask.additionalArgs) {
+        args.push(...pqTestTask.additionalArgs);
     }
 
-    if (pqTestTaskBase.pathToQueryFile) {
-        args.unshift(pqTestTaskBase.pathToQueryFile);
+    if (pqTestTask.pathToQueryFile) {
+        args.unshift(pqTestTask.pathToQueryFile);
         args.unshift("--queryFile");
     }
 
-    if (pqTestTaskBase.pathToConnector) {
-        args.unshift(pqTestTaskBase.pathToConnector);
+    if (pqTestTask.pathToConnector) {
+        args.unshift(pqTestTask.pathToConnector);
         args.unshift("--extension");
     }
 
-    args.unshift(pqTestTaskBase.operation);
+    args.unshift(pqTestTask.operation);
 
     return args;
 }

--- a/src/common/PowerQueryTask.ts
+++ b/src/common/PowerQueryTask.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as vscode from "vscode";
+import { OperationType } from "./OperationType";
+
+// Properties that need to be persisted as part of the task definition should be
+// included in the taskDefinitions section of package.json.
+
+export interface PowerQueryTask {
+    readonly operation: OperationType;
+    readonly additionalArgs?: string[];
+    readonly label?: string;
+}
+
+export interface PQTestTask extends PowerQueryTask {
+    // TODO: Are we using "Connector" or "Extension" terminology?
+    readonly pathToConnector?: string;
+    readonly pathToQueryFile?: string;
+    readonly stdinStr?: string;
+}
+
+export interface PowerQueryTaskDefinition extends PQTestTask, vscode.TaskDefinition {}

--- a/src/constants/PowerQuerySdkExtension.ts
+++ b/src/constants/PowerQuerySdkExtension.ts
@@ -32,8 +32,8 @@ const ConfigPathToTestConnectionFile: string =
 
 const PQLanguageId: string = "powerquery";
 const OutputChannelName: string = "Power Query SDK";
-const PQTestTaskType: string = PQLanguageId;
-const PQDebugType: string = PQTestTaskType;
+const PowerQueryTaskType: string = PQLanguageId;
+const PQDebugType: string = PowerQueryTaskType;
 
 const NugetBaseFolder: string = ".nuget" as const;
 const NugetConfigFileName: string = "nuget-staging.config" as const;
@@ -53,7 +53,7 @@ export const ExtensionConstants = Object.freeze({
     ConfigPathToTestConnectionFile,
     PQLanguageId,
     OutputChannelName,
-    PQTestTaskType,
+    PowerQueryTaskType,
     PQDebugType,
     NugetBaseFolder,
     NugetConfigFileName,

--- a/src/features/PowerQueryTaskProvider.ts
+++ b/src/features/PowerQueryTaskProvider.ts
@@ -6,29 +6,33 @@
  */
 
 import * as vscode from "vscode";
-import { buildPqTestArgs, IPQTestService, PQTestTaskDefinition } from "common/PQTestService";
+import { buildPqTestArgs, IPQTestService } from "common/PQTestService";
 import { ExtensionConstants } from "constants/PowerQuerySdkExtension";
+import { PowerQueryTaskDefinition } from "common/PowerQueryTask";
 
-const TaskSource: string = "pqtest";
+const enum TaskLabelPrefix {
+    Build = "build",
+    PQTest = "pqtest",
+}
 
-const pqTestOperations: PQTestTaskDefinition[] = [
-    { type: ExtensionConstants.PQTestTaskType, operation: "list-credential", label: "List credentials" },
+const pqTestOperations: PowerQueryTaskDefinition[] = [
+    { type: ExtensionConstants.PowerQueryTaskType, operation: "list-credential", label: "List credentials" },
     // TODO: Can we prompt to confirm that user really wants to remove all credentials?
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "delete-credential",
         label: "Clear ALL credentials",
         additionalArgs: ["--ALL"],
     },
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "info",
         label: "Connector info",
         pathToConnector: ExtensionConstants.ConfigPathToConnector,
     },
     // TODO: We need logic to determine which authentication kind to use (when there is more than one)
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "set-credential",
         label: "Set credential",
         additionalArgs: ["--interactive"],
@@ -37,7 +41,7 @@ const pqTestOperations: PQTestTaskDefinition[] = [
     },
     // TODO: This one should only be included for connectors with OAuth and Aad
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "refresh-credential",
         label: "Refresh credential",
         pathToConnector: ExtensionConstants.ConfigPathToConnector,
@@ -45,14 +49,14 @@ const pqTestOperations: PQTestTaskDefinition[] = [
     },
     // TODO: How can we format the output?
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "run-test",
         label: "Evaluate current file",
         pathToConnector: ExtensionConstants.ConfigPathToConnector,
         pathToQueryFile: "${file}",
     },
     {
-        type: ExtensionConstants.PQTestTaskType,
+        type: ExtensionConstants.PowerQueryTaskType,
         operation: "test-connection",
         label: "Test connection",
         pathToConnector: ExtensionConstants.ConfigPathToConnector,
@@ -60,13 +64,57 @@ const pqTestOperations: PQTestTaskDefinition[] = [
     },
 ];
 
+const buildTasks: PowerQueryTaskDefinition[] = [
+    {
+        type: ExtensionConstants.PowerQueryTaskType,
+        operation: "msbuild",
+        label: "Build connector project using MSBuild",
+        additionalArgs: ["/restore", "/consoleloggerparameters:NoSummary", "/property:GenerateFullPaths=true"],
+    },
+];
+
 export class PowerQueryTaskProvider implements vscode.TaskProvider {
-    static TaskType: string = ExtensionConstants.PQTestTaskType;
+    static TaskType: string = ExtensionConstants.PowerQueryTaskType;
 
     constructor(protected readonly pqTestService: IPQTestService) {}
 
-    // todo getTaskForTaskDefinition can be static
-    private getTaskForTaskDefinition(taskDef: PQTestTaskDefinition, pqtestExe: string): vscode.Task {
+    public provideTasks(_token: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
+        const result: vscode.Task[] = [];
+
+        buildTasks.forEach((taskDef: PowerQueryTaskDefinition) => {
+            result.push(PowerQueryTaskProvider.getTaskForBuildTaskDefinition(taskDef));
+        });
+
+        if (!this.pqTestService.pqTestReady) {
+            return result;
+        }
+
+        pqTestOperations.forEach((taskDef: PowerQueryTaskDefinition) => {
+            result.push(
+                PowerQueryTaskProvider.getTaskForPQTestTaskDefinition(taskDef, this.pqTestService.pqTestFullPath),
+            );
+        });
+
+        return result;
+    }
+
+    public resolveTask(task: vscode.Task, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        const taskDef: PowerQueryTaskDefinition = task.definition as PowerQueryTaskDefinition;
+
+        if (taskDef.operation === "msbuild") {
+            return PowerQueryTaskProvider.getTaskForBuildTaskDefinition(taskDef);
+        }
+
+        const pqtestExe: string = this.pqTestService.pqTestFullPath;
+
+        if (pqtestExe && !token.isCancellationRequested) {
+            return PowerQueryTaskProvider.getTaskForPQTestTaskDefinition(taskDef, pqtestExe);
+        }
+
+        return undefined;
+    }
+
+    private static getTaskForPQTestTaskDefinition(taskDef: PowerQueryTaskDefinition, pqtestExe: string): vscode.Task {
         const args: string[] = buildPqTestArgs(taskDef);
         const processExecution: vscode.ProcessExecution = new vscode.ProcessExecution(pqtestExe, args);
 
@@ -75,35 +123,38 @@ export class PowerQueryTaskProvider implements vscode.TaskProvider {
             taskDef,
             vscode.TaskScope.Workspace,
             taskDef.label ?? taskDef.operation,
-            TaskSource,
+            TaskLabelPrefix.PQTest,
             processExecution,
             [] /* problemMatchers */,
         );
     }
 
-    public provideTasks(_token: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
-        const result: vscode.Task[] = [];
+    private static getTaskForBuildTaskDefinition(taskDef: PowerQueryTaskDefinition): vscode.Task {
+        // TODO: To support SDK based build we'll need to:
+        // - Check the kind on the taskDef
+        // - Change ShellExecution to CustomExecution
+        // - Update the problem matcher
+        const execution: vscode.ShellExecution = new vscode.ShellExecution("msbuild");
 
-        if (!this.pqTestService.pqTestReady) {
-            return result;
+        if (taskDef.additionalArgs && taskDef.additionalArgs.length > 0) {
+            execution.args.push(...taskDef.additionalArgs);
         }
 
-        pqTestOperations.forEach((taskDef: PQTestTaskDefinition) => {
-            result.push(this.getTaskForTaskDefinition(taskDef, this.pqTestService.pqTestFullPath));
-        });
+        const task: vscode.Task = new vscode.Task(
+            taskDef,
+            vscode.TaskScope.Workspace,
+            taskDef.label ?? taskDef.operation,
+            TaskLabelPrefix.Build,
+            execution,
+            ["$msCompile"],
+        );
 
-        return result;
-    }
+        task.group = vscode.TaskGroup.Build;
 
-    public resolveTask(task: vscode.Task, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
-        const pqtestExe: string = this.pqTestService.pqTestFullPath;
+        task.presentationOptions = {
+            reveal: vscode.TaskRevealKind.Silent,
+        };
 
-        if (pqtestExe && !token.isCancellationRequested) {
-            const taskDef: PQTestTaskDefinition = task.definition as PQTestTaskDefinition;
-
-            return this.getTaskForTaskDefinition(taskDef, pqtestExe);
-        }
-
-        return undefined;
+        return task;
     }
 }

--- a/src/pqTestConnector/PqTestExecutableOnceTask.ts
+++ b/src/pqTestConnector/PqTestExecutableOnceTask.ts
@@ -9,13 +9,14 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { buildPqTestArgs, PQTestTaskBase } from "common/PQTestService";
 import { DisposableEventEmitter, ExtractEventTypes } from "common/DisposableEventEmitter";
 import { ProcessExit, SpawnedProcess } from "common/SpawnedProcess";
+import { buildPqTestArgs } from "common/PQTestService";
 import { ChildProcessWithoutNullStreams } from "child_process";
 import { ExtensionConfigurations } from "constants/PowerQuerySdkConfiguration";
 import { IDisposable } from "common/Disposable";
 import { PqTestResultViewPanel } from "panels/PqTestResultViewPanel";
+import { PQTestTask } from "common/PowerQueryTask";
 import { resolveSubstitutedValues } from "utils/vscodes";
 
 // eslint-disable-next-line @typescript-eslint/typedef
@@ -96,8 +97,8 @@ export class PqTestExecutableOnceTask implements IDisposable {
         return pqtestExe;
     }
 
-    private populateTestTaskPayload(program: string, task: PQTestTaskBase): PQTestTaskBase {
-        let result: PQTestTaskBase = task;
+    private populateTestTaskPayload(program: string, task: PQTestTask): PQTestTask {
+        let result: PQTestTask = task;
 
         // even though not all operations would be run within this OnceTask, it makes no harm we support them all
         switch (task.operation) {
@@ -130,7 +131,7 @@ export class PqTestExecutableOnceTask implements IDisposable {
         return result;
     }
 
-    public async run(program: string, task: PQTestTaskBase): Promise<void> {
+    public async run(program: string, task: PQTestTask): Promise<void> {
         try {
             task = this.populateTestTaskPayload(program, task);
             this._pathToQueryFile = task.pathToQueryFile;

--- a/src/pqTestConnector/PqTestExecutableTaskQueue.ts
+++ b/src/pqTestConnector/PqTestExecutableTaskQueue.ts
@@ -8,7 +8,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { buildPqTestArgs, GenericResult, IPQTestService, PQTestTaskBase } from "common/PQTestService";
+import { buildPqTestArgs, GenericResult, IPQTestService } from "common/PQTestService";
 import { Disposable, IDisposable } from "common/Disposable";
 import { DisposableEventEmitter, ExtractEventTypes } from "common/DisposableEventEmitter";
 import { ExtensionContext, TextEditor } from "vscode";
@@ -23,6 +23,7 @@ import { resolveSubstitutedValues } from "utils/vscodes";
 
 import { ChildProcessWithoutNullStreams } from "child_process";
 import { ExtensionConfigurations } from "constants/PowerQuerySdkConfiguration";
+import { PQTestTask } from "common/PowerQueryTask";
 
 // eslint-disable-next-line @typescript-eslint/typedef
 export const PqTestExecutableTaskQueueEvents = {
@@ -34,7 +35,7 @@ type PqTestExecutableTaskQueueEventTypes = ExtractEventTypes<typeof PqTestExecut
 /**
  * Internal interface within the module, we need not cast members as readonly
  */
-interface PqTestExecutableTask extends PQTestTaskBase {
+interface PqTestExecutableTask extends PQTestTask {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolve: (res: any) => void;
     reject: (reason: Error | string) => void;
@@ -231,7 +232,7 @@ export class PqTestExecutableTaskQueue implements IPQTestService, IDisposable {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private doEnqueueOneTask<T = any>(task: PQTestTaskBase): Promise<T> {
+    private doEnqueueOneTask<T = any>(task: PQTestTask): Promise<T> {
         const theTask: PqTestExecutableTask = task as PqTestExecutableTask;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Add a new "build" task source and MSBuild focused build task. We'll eventually add an SDK-style build task as well that works without an MSBuild pre-requisite. The current implementation assumes that MSBuild will already be in the PATH. We can add support for a configurable build path in a follow up change.