### PR TITLE
fix. 844054 prefer dirname over exe full path for nuget&msbuild config

### DIFF
--- a/src/constants/PowerQuerySdkConfiguration.ts
+++ b/src/constants/PowerQuerySdkConfiguration.ts
@@ -6,6 +6,7 @@
  */
 
 import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 import { ConfigurationTarget } from "vscode";
 
@@ -23,6 +24,10 @@ export const ExtensionConfigurations = {
             ExtensionConstants.ConfigNames.PowerQuerySdk.name,
         );
 
+        if (msbuildFullPath && msbuildFullPath.indexOf(ExtensionConstants.MSBuildExecutableName) !== -1) {
+            msbuildFullPath = path.dirname(msbuildFullPath);
+        }
+
         return config.update(
             ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsMsbuildPath,
             msbuildFullPath,
@@ -34,7 +39,15 @@ export const ExtensionConfigurations = {
             ExtensionConstants.ConfigNames.PowerQuerySdk.name,
         );
 
-        return config.get(ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsMsbuildPath);
+        let result: string | undefined = config.get(
+            ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsMsbuildPath,
+        );
+
+        if (result) {
+            result = path.join(result, ExtensionConstants.MSBuildExecutableName);
+        }
+
+        return result;
     },
     setNugetPath(
         nugetFullPath: string | undefined,
@@ -44,6 +57,10 @@ export const ExtensionConfigurations = {
         const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
             ExtensionConstants.ConfigNames.PowerQuerySdk.name,
         );
+
+        if (nugetFullPath && nugetFullPath.indexOf(ExtensionConstants.NugetExecutableName) !== -1) {
+            nugetFullPath = path.dirname(nugetFullPath);
+        }
 
         return config.update(
             ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsNugetPath,
@@ -56,7 +73,15 @@ export const ExtensionConfigurations = {
             ExtensionConstants.ConfigNames.PowerQuerySdk.name,
         );
 
-        return config.get(ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsNugetPath);
+        let result: string | undefined = config.get(
+            ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsNugetPath,
+        );
+
+        if (result) {
+            result = path.join(result, ExtensionConstants.NugetExecutableName);
+        }
+
+        return result;
     },
     setPQTestLocation(
         pqTestLocation: string | undefined,
@@ -185,7 +210,7 @@ export function activateExternalConfiguration(promptWarningMessage: boolean = fa
     let hasMsbuildFromCurConfig: boolean = Boolean(msbuildFromCurConfig && fs.existsSync(msbuildFromCurConfig));
 
     if (!hasNugetFromCurConfig) {
-        const nugetFromThePath: string | undefined = findExecutable("nuget", [".exe", ""]);
+        const nugetFromThePath: string | undefined = findExecutable("Nuget", [".exe", ""]);
         hasNugetFromCurConfig = Boolean(nugetFromThePath);
         void ExtensionConfigurations.setNugetPath(nugetFromThePath);
     }

--- a/src/constants/PowerQuerySdkExtension.ts
+++ b/src/constants/PowerQuerySdkExtension.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root of this projects source tree.
  */
 
+import * as os from "os";
+
 // todo: should we rename it into ms.vscode-powerquery-sdk which is more authentic?
 const ExtensionId: string = "vscode-powerquery-sdk";
 
@@ -51,6 +53,14 @@ function buildPqTestSubPath(pqTestVersion: string): string[] {
 const NugetDownloadUrl: string = "https://www.nuget.org/downloads" as const;
 const MSBuildDownloadUrl: string = "https://visualstudio.microsoft.com/downloads/?q=build+tools" as const;
 
+/**
+ * It might be bash script like:
+ *     `exec /usr/bin/memo /usr/lib/mono/nuget/Nuget.exe`
+ */
+const NugetExecutableName: string = os.type() === "Windows_NT" ? "Nuget.exe" : "nuget";
+
+const MSBuildExecutableName: string = "MSBuild.exe" as const;
+
 // eslint-disable-next-line @typescript-eslint/typedef
 export const ExtensionConstants = Object.freeze({
     ExtensionId,
@@ -69,4 +79,6 @@ export const ExtensionConstants = Object.freeze({
     ConfigNames,
     NugetDownloadUrl,
     MSBuildDownloadUrl,
+    NugetExecutableName,
+    MSBuildExecutableName,
 });


### PR DESCRIPTION
fix. 844054 prefer dirname over exe full path for nuget&msbuild config
![image](https://user-images.githubusercontent.com/69623692/177102392-e9aefbd3-c862-4846-be44-6567e3e24c27.png)
