### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 585: Build ID 353210

### DIFF
--- a/localize/i18n/bg-BG/package.nls.json
+++ b/localize/i18n/bg-BG/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ca-ES/package.nls.json
+++ b/localize/i18n/ca-ES/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/cs-CZ/package.nls.json
+++ b/localize/i18n/cs-CZ/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/da-DK/package.nls.json
+++ b/localize/i18n/da-DK/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/de-DE/package.nls.json
+++ b/localize/i18n/de-DE/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/el-GR/package.nls.json
+++ b/localize/i18n/el-GR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/es-ES/package.nls.json
+++ b/localize/i18n/es-ES/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/et-EE/package.nls.json
+++ b/localize/i18n/et-EE/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/eu-ES/package.nls.json
+++ b/localize/i18n/eu-ES/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/fi-FI/package.nls.json
+++ b/localize/i18n/fi-FI/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/fr-FR/package.nls.json
+++ b/localize/i18n/fr-FR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/gl-ES/package.nls.json
+++ b/localize/i18n/gl-ES/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/hi-IN/package.nls.json
+++ b/localize/i18n/hi-IN/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/hr-HR/package.nls.json
+++ b/localize/i18n/hr-HR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/hu-HU/package.nls.json
+++ b/localize/i18n/hu-HU/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/id-ID/package.nls.json
+++ b/localize/i18n/id-ID/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/it-IT/package.nls.json
+++ b/localize/i18n/it-IT/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ja-JP/package.nls.json
+++ b/localize/i18n/ja-JP/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/kk-KZ/package.nls.json
+++ b/localize/i18n/kk-KZ/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ko-KR/package.nls.json
+++ b/localize/i18n/ko-KR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/lt-LT/package.nls.json
+++ b/localize/i18n/lt-LT/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/lv-LV/package.nls.json
+++ b/localize/i18n/lv-LV/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ms-MY/package.nls.json
+++ b/localize/i18n/ms-MY/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/nb-NO/package.nls.json
+++ b/localize/i18n/nb-NO/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/nl-NL/package.nls.json
+++ b/localize/i18n/nl-NL/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/pl-PL/package.nls.json
+++ b/localize/i18n/pl-PL/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/pt-BR/package.nls.json
+++ b/localize/i18n/pt-BR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/pt-PT/package.nls.json
+++ b/localize/i18n/pt-PT/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ro-RO/package.nls.json
+++ b/localize/i18n/ro-RO/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/ru-RU/package.nls.json
+++ b/localize/i18n/ru-RU/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/sk-SK/package.nls.json
+++ b/localize/i18n/sk-SK/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/sl-SI/package.nls.json
+++ b/localize/i18n/sl-SI/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/sr-Cyrl-RS/package.nls.json
+++ b/localize/i18n/sr-Cyrl-RS/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/sr-Latn-RS/package.nls.json
+++ b/localize/i18n/sr-Latn-RS/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/sv-SE/package.nls.json
+++ b/localize/i18n/sv-SE/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/th-TH/package.nls.json
+++ b/localize/i18n/th-TH/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/tr-TR/package.nls.json
+++ b/localize/i18n/tr-TR/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/uk-UA/package.nls.json
+++ b/localize/i18n/uk-UA/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/vi-VN/package.nls.json
+++ b/localize/i18n/vi-VN/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/zh-CN/package.nls.json
+++ b/localize/i18n/zh-CN/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/localize/i18n/zh-TW/package.nls.json
+++ b/localize/i18n/zh-TW/package.nls.json
@@ -1,3 +1,24 @@
 {
-  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query script"
+  "extension.pqtest.RunTestBatteryCommand.title": "Evaluate current power query file.",
+  "extension.pqtest.SetupCurrentWorkspaceCommand.title": "Setup workspace",
+  "extension.pqtest.config.project.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
+  "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
+  "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",
+  "extension.pqtest.config.pqtest.extension.description": "Specify connector extension source modules (.mez/.pqm).<br>This option can be specified more than once.",
+  "extension.pqtest.config.pqtest.queryFile.description": "Query file containing section document or M expression (.m/.pq).",
+  "extension.pqtest.taskDefinitions.properties.operation.description": "The operation to run",
+  "extension.pqtest.taskDefinitions.properties.additionalArgs.description": "Additional commandline arguments for the operation",
+  "extension.pqtest.taskDefinitions.properties.pathToConnector.description": "Path to the connector file (--extension)",
+  "extension.pqtest.taskDefinitions.properties.pathToQueryFile.description": "Path to the query file (--queryFile)",
+  "extension.pqtest.explorer.name": "Power query SDK",
+  "extension.pqtest.welcome.contents": "In order to use extension features, you need to create an Power query extension project.\n[Create an extension project](command:powerquery.sdk.pqtest.CreateNewProjectCommand)\nTo learn more about how to create an extension, [read our docs](https://docs.microsoft.com/en-us/powerquery-m/).",
+  "extension.pqtest.debugger.properties.program.description": "Absolute path to a power query file.",
+  "extension.pqtest.debugger.properties.trace.description": "Enable logging of the Debug",
+  "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
+  "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
+  "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
+  "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
+  "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.