### PR TITLE
fix.[Credentials] Prompt for Anonymous/Implicit credential type shoul…

### DIFF
--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -1091,7 +1091,7 @@ export class LifecycleCommands {
                         }
 
                         const items: vscode.QuickPickItem[] = currentAuthCandidates.map((one: string) => ({
-                            label: one,
+                            label: one.toLowerCase() === "implicit" ? "Anonymous" : one,
                         }));
 
                         const picked: vscode.QuickPickItem = await input.showQuickPick({


### PR DESCRIPTION
I tested against the serviceHost and command service, both populated the anonymous/implicit credentials as expected.

service host:
![image](https://user-images.githubusercontent.com/69623692/187217137-3a52d185-0ec5-4084-b329-b8e49fe959dd.png)

command mode:
![image](https://user-images.githubusercontent.com/69623692/187217329-1bcdf055-62da-4c92-a7ac-3dc56645d3d4.png)
