### PR TITLE
Add incremental build support to msbuild proj file template

### DIFF
--- a/templates/PQConn.proj
+++ b/templates/PQConn.proj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Clean;BuildMez">
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="BuildMez">
   <PropertyGroup>
     <OutputPath Condition="'$(OutputPath)' == ''">$(MSBuildProjectDirectory)\bin\</OutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(MSBuildProjectDirectory)\obj\</IntermediateOutputPath>
@@ -18,12 +18,11 @@
     <MezContent Include="{{ProjectName}}80.png" />
     <MezContent Include="resources.resx" />
   </ItemGroup>
-  <Target Name="BuildMez" DependsOnTargets="CopyMezContent" AfterTargets="Build">
+  <Target Name="BuildMez" AfterTargets="Build" Inputs="@(MezContent)" Outputs="$(MezOutputPath)">
+    <RemoveDir Directories="$(MezIntermediatePath)" />
+    <Copy SourceFiles="@(MezContent)" DestinationFolder="$(MezIntermediatePath)" />
     <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
     <ZipDirectory SourceDirectory="$(MezIntermediatePath)" DestinationFile="$(MezOutputPath)" Overwrite="true" />
-  </Target>
-  <Target Name="CopyMezContent" AfterTargets="BeforeBuild">
-    <Copy SourceFiles="@(MezContent)" DestinationFolder="$(MezIntermediatePath)" />
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="$(MezIntermediatePath)" />


### PR DESCRIPTION
Removes Clean as a default step, and adds `Inputs` and `Outputs` to the `BuildMez` target. This allows MSBuild to determine whether a mez update is required based on timestamps.

Resolves #54 