### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 585: Build ID 370619

### DIFF
--- a/localize/i18n/bg-BG/extension.json
+++ b/localize/i18n/bg-BG/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ca-ES/extension.json
+++ b/localize/i18n/ca-ES/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/cs-CZ/extension.json
+++ b/localize/i18n/cs-CZ/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/da-DK/extension.json
+++ b/localize/i18n/da-DK/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/de-DE/extension.json
+++ b/localize/i18n/de-DE/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/el-GR/extension.json
+++ b/localize/i18n/el-GR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/es-ES/extension.json
+++ b/localize/i18n/es-ES/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/et-EE/extension.json
+++ b/localize/i18n/et-EE/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/eu-ES/extension.json
+++ b/localize/i18n/eu-ES/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/fi-FI/extension.json
+++ b/localize/i18n/fi-FI/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/fr-FR/extension.json
+++ b/localize/i18n/fr-FR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/gl-ES/extension.json
+++ b/localize/i18n/gl-ES/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/hi-IN/extension.json
+++ b/localize/i18n/hi-IN/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/hr-HR/extension.json
+++ b/localize/i18n/hr-HR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/hu-HU/extension.json
+++ b/localize/i18n/hu-HU/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/id-ID/extension.json
+++ b/localize/i18n/id-ID/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/it-IT/extension.json
+++ b/localize/i18n/it-IT/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ja-JP/extension.json
+++ b/localize/i18n/ja-JP/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/kk-KZ/extension.json
+++ b/localize/i18n/kk-KZ/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ko-KR/extension.json
+++ b/localize/i18n/ko-KR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/lt-LT/extension.json
+++ b/localize/i18n/lt-LT/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/lv-LV/extension.json
+++ b/localize/i18n/lv-LV/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ms-MY/extension.json
+++ b/localize/i18n/ms-MY/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/nb-NO/extension.json
+++ b/localize/i18n/nb-NO/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/nl-NL/extension.json
+++ b/localize/i18n/nl-NL/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/pl-PL/extension.json
+++ b/localize/i18n/pl-PL/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/pt-BR/extension.json
+++ b/localize/i18n/pt-BR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/pt-PT/extension.json
+++ b/localize/i18n/pt-PT/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ro-RO/extension.json
+++ b/localize/i18n/ro-RO/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/ru-RU/extension.json
+++ b/localize/i18n/ru-RU/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/sk-SK/extension.json
+++ b/localize/i18n/sk-SK/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/sl-SI/extension.json
+++ b/localize/i18n/sl-SI/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/sr-Cyrl-RS/extension.json
+++ b/localize/i18n/sr-Cyrl-RS/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/sr-Latn-RS/extension.json
+++ b/localize/i18n/sr-Latn-RS/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/sv-SE/extension.json
+++ b/localize/i18n/sv-SE/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/th-TH/extension.json
+++ b/localize/i18n/th-TH/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/tr-TR/extension.json
+++ b/localize/i18n/tr-TR/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/uk-UA/extension.json
+++ b/localize/i18n/uk-UA/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/vi-VN/extension.json
+++ b/localize/i18n/vi-VN/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/zh-CN/extension.json
+++ b/localize/i18n/zh-CN/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",

--- a/localize/i18n/zh-TW/extension.json
+++ b/localize/i18n/zh-TW/extension.json
@@ -13,6 +13,8 @@
   "PQSdk.lifecycle.command.new.project.placeHolder": "Only lower cases or upper cases characters are allowed",
   "PQSdk.lifecycle.command.new.project.created": "New {newProjName}.pq and other files have been created at {targetFolder}",
   "PQSdk.lifecycle.command.select.workspace": "Select workspace",
+  "PQSdk.lifecycle.command.update.sdkTool.errorMessage": "Fail to update PQSdk tools due to {errorMessage}",
+  "PQSdk.lifecycle.command.manuallyUpdate.sdkTool.errorMessage": "Fail to manually update PQSdk tools due to {errorMessage}",
   "PQSdk.lifecycle.command.delete.credentials.title": "Deleting credentials",
   "PQSdk.lifecycle.command.delete.credentials.result": "DeleteCredential result {result}",
   "PQSdk.lifecycle.command.delete.credentials.errorMessage": "Fail to delete credentials due to {errorMessage}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.