### PR TITLE
fix 907273 support additionalArgs for dba

### DIFF
--- a/localize/i18n/bg-BG/package.nls.json
+++ b/localize/i18n/bg-BG/package.nls.json
@@ -28,6 +28,7 @@
   "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
   "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
   "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
+  "extension.pqtest.debugger.properties.additionalArgs.description": "Additional arguments for current operation",
   "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
   "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }

--- a/package.json
+++ b/package.json
@@ -276,6 +276,14 @@
                                     "%extension.pqtest.debugger.properties.operation.testConnection.description%"
                                 ],
                                 "default": "run-test"
+                            },
+                            "additionalArgs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "%extension.pqtest.debugger.properties.additionalArgs.description%",
+                                "default": []
                             }
                         }
                     }


### PR DESCRIPTION
fix 907273 support property additionalArgs for debugger adapter as the one in the task definition
![image](https://user-images.githubusercontent.com/69623692/191909785-2753ece6-27f2-4e19-ab40-917d552d568a.png)
