### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 585: Build ID 375296

### DIFF
--- a/localize/i18n/bg-BG/package.nls.json
+++ b/localize/i18n/bg-BG/package.nls.json
@@ -28,7 +28,6 @@
   "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
   "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
   "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
-  "extension.pqtest.debugger.properties.additionalArgs.description": "Additional arguments for current operation",
   "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
   "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.