### PR TITLE
fix. e2e test again the expected drop output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
 dist
 out
+scripts
 **/*.js

--- a/.pipelines/pr-pipeline.yml
+++ b/.pipelines/pr-pipeline.yml
@@ -36,18 +36,18 @@ steps:
       customCommand: "run test:unit-test"
 
   - task: Npm@1
+    displayName: "build VSIX"
+    inputs:
+      command: "custom"
+      customCommand: "run vsix"
+
+  - task: Npm@1
     displayName: "npm e2e test"
     enabled: 'true'
     continueOnError: 'true'
     inputs:
       command: "custom"
       customCommand: "run test:e2e"
-
-  - task: Npm@1
-    displayName: "build VSIX"
-    inputs:
-      command: "custom"
-      customCommand: "run vsix"
 
   - task: PoliCheck@1
     inputs:

--- a/.pipelines/pr-pipeline.yml
+++ b/.pipelines/pr-pipeline.yml
@@ -44,6 +44,7 @@ steps:
   - task: Npm@1
     displayName: "npm e2e test"
     enabled: 'true'
+    retryCountOnTaskFailure: 5
     continueOnError: 'true'
     inputs:
       command: "custom"

--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
         "audit": "npm audit --production",
         "lint": "eslint src --ext ts",
         "test:unit-test": "mocha -r ts-node/register -s 0 \"./unit-tests/**/*.spec.ts\"",
-        "test:e2e": "npm run compile-tests && extest setup-and-run out/src/test/**/*.spec.js",
+        "test:e2e": "npm run compile-tests && ts-node scripts/test-e2e.ts",
         "test": "npm run test:unit-test && npm run test:e2e",
         "vsix": "npx vsce package --target win32-x64",
         "code-install": "ts-node scripts/install.ts"

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1,19 +1,16 @@
-import * as fs from "fs";
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
 import * as cp from "child_process";
+import { getFirstVsixFileDirectlyBeneathOneDirectory } from "./utils/vsixs";
 
 const cwd = process.cwd();
 
-const dirents: fs.Dirent[] = fs.readdirSync(cwd, { withFileTypes: true });
-
-let oneVsixFile: string = "";
-
-dirents.some((dirent: fs.Dirent) => {
-    if (!dirent.isDirectory() && dirent.name.endsWith(".vsix")) {
-        oneVsixFile = dirent.name;
-        return true;
-    }
-    return false;
-});
+let oneVsixFile: string = getFirstVsixFileDirectlyBeneathOneDirectory(process.cwd());
 
 if (oneVsixFile) {
     cp.execSync(`code --install-extension ${oneVsixFile}`, { cwd });

--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT license found in the
  * LICENSE file in the root of this projects source tree.
  */
+import * as path from "path";
 
 import { ExTester } from "vscode-extension-tester";
 import { getFirstVsixFileDirectlyBeneathOneDirectory } from "./utils/vsixs";
@@ -13,8 +14,13 @@ const theVsixFilePath: string = getFirstVsixFileDirectlyBeneathOneDirectory(proc
 async function doE2eTest() {
     const extTest = new ExTester();
 
-    await extTest.installVsix({ vsixFile: theVsixFilePath });
+    // Performs all necessary setup: getting VSCode + ChromeDriver and packaging/installing extension into the test instance
+    await extTest.setupRequirements();
 
+    // Install the extension into the test instance of VS Code
+    await extTest.installVsix({ vsixFile: path.resolve(process.cwd(), theVsixFilePath) });
+
+    // Runs the selected test files in VS Code using mocha and webdriver
     await extTest.runTests("out/src/test/**/*.spec.js", { cleanup: true });
 }
 

--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root of this projects source tree.
  */
 
-import * as path from "path";
-
 import { ExTester } from "vscode-extension-tester";
 import { getFirstVsixFileDirectlyBeneathOneDirectory } from "./utils/vsixs";
 
@@ -15,7 +13,7 @@ const theVsixFilePath: string = getFirstVsixFileDirectlyBeneathOneDirectory(proc
 async function doE2eTest() {
     const extTest = new ExTester();
 
-    await extTest.installVsix({ vsixFile: path.resolve(process.cwd(), theVsixFilePath) });
+    await extTest.installVsix({ vsixFile: theVsixFilePath });
 
     await extTest.runTests("out/src/test/**/*.spec.js", { cleanup: true });
 }

--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as path from "path";
+
+import { ExTester } from "vscode-extension-tester";
+import { getFirstVsixFileDirectlyBeneathOneDirectory } from "./utils/vsixs";
+
+const theVsixFilePath: string = getFirstVsixFileDirectlyBeneathOneDirectory(process.cwd());
+
+async function doE2eTest() {
+    const extTest = new ExTester();
+
+    await extTest.installVsix({ vsixFile: path.resolve(process.cwd(), theVsixFilePath) });
+
+    await extTest.runTests("out/src/test/**/*.spec.js", { cleanup: true });
+}
+
+void doE2eTest();

--- a/scripts/test-e2e.ts
+++ b/scripts/test-e2e.ts
@@ -14,8 +14,9 @@ const theVsixFilePath: string = getFirstVsixFileDirectlyBeneathOneDirectory(proc
 async function doE2eTest() {
     const extTest = new ExTester();
 
-    // Performs all necessary setup: getting VSCode + ChromeDriver and packaging/installing extension into the test instance
-    await extTest.setupRequirements();
+    // Performs all necessary setup: getting VSCode + ChromeDriver into the test instance
+    await extTest.downloadCode();
+    await extTest.downloadChromeDriver();
 
     // Install the extension into the test instance of VS Code
     await extTest.installVsix({ vsixFile: path.resolve(process.cwd(), theVsixFilePath) });

--- a/scripts/utils/vsixs.ts
+++ b/scripts/utils/vsixs.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import fs from "fs";
+
+export function getFirstVsixFileDirectlyBeneathOneDirectory(targetDirectory: string) {
+    const dirents: fs.Dirent[] = fs.readdirSync(targetDirectory, { withFileTypes: true });
+
+    let oneVsixFile: string = "";
+
+    dirents.some((dirent: fs.Dirent) => {
+        if (!dirent.isDirectory() && dirent.name.endsWith(".vsix")) {
+            oneVsixFile = dirent.name;
+            return true;
+        }
+        return false;
+    });
+
+    return oneVsixFile;
+}


### PR DESCRIPTION
fix. we should always do e2e test against the built one and put the e2e-tested bits into the drop and set its retryCountOnTaskFailure up to 5

![image](https://user-images.githubusercontent.com/69623692/192710934-1e659261-269e-42c8-87fa-b3a19f0b9d20.png)
https://dev.azure.com/ms/powerquery-language-services/_build/results?buildId=376461&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=cba44fe4-08a1-5a94-3e6b-afbd3327ccb9&l=52

and there would be only one vsix left:
![image](https://user-images.githubusercontent.com/69623692/192719391-eb5401f1-1366-4376-9776-0d3ac79dda31.png)

