### PR TITLE
feat. 917170 replace staging nuget config w/ nuget feed url setting item

### DIFF
--- a/etc/nuget-staging.config
+++ b/etc/nuget-staging.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="PowerBiComponents" value="https://powerbi.pkgs.visualstudio.com/_packaging/PowerBiComponents/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/package.json
+++ b/package.json
@@ -152,6 +152,12 @@
                     "type": "string",
                     "description": "%extension.pqtest.config.externals.nugetPath.description%"
                 },
+                "powerquery.sdk.externals.nugetFeed": {
+                    "scope": "window",
+                    "type": "string",
+                    "description": "%extension.pqtest.config.externals.nugetFeed.description%",
+                    "default": ""
+                },
                 "powerquery.sdk.tools.location": {
                     "scope": "machine-overridable",
                     "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,7 @@
     "extension.pqtest.TestConnectionCommand.title": "Test connection",
     "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
     "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+    "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
     "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
     "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
     "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -516,12 +516,11 @@ export class LifecycleCommands implements IDisposable {
             fs.mkdirSync(baseNugetFolder);
         }
 
-        const args: string[] = [
-            "list",
-            ExtensionConstants.InternalMsftPqSdkToolsNugetName,
-            "-ConfigFile",
-            path.resolve(this.vscExtCtx.extensionPath, "etc", ExtensionConstants.NugetConfigFileName),
-        ];
+        const args: string[] = ["list", ExtensionConstants.InternalMsftPqSdkToolsNugetName];
+
+        if (ExtensionConfigurations.nugetFeed) {
+            args.push("-Source", ExtensionConfigurations.nugetFeed);
+        }
 
         const seizingProcess: SpawnedProcess = new SpawnedProcess(ExtensionConfigurations.nugetPath ?? "nuget", args, {
             cwd: baseNugetFolder,
@@ -560,11 +559,13 @@ export class LifecycleCommands implements IDisposable {
                 ExtensionConstants.InternalMsftPqSdkToolsNugetName,
                 "-Version",
                 maybeNextVersion ?? ExtensionConstants.SuggestedPqTestNugetVersion,
-                "-ConfigFile",
-                path.resolve(this.vscExtCtx.extensionPath, "etc", ExtensionConstants.NugetConfigFileName),
                 "-OutputDirectory",
                 baseNugetFolder,
             ];
+
+            if (ExtensionConfigurations.nugetFeed) {
+                args.push("-Source", ExtensionConfigurations.nugetFeed);
+            }
 
             const seizingProcess: SpawnedProcess = new SpawnedProcess(
                 ExtensionConfigurations.nugetPath ?? "nuget",

--- a/src/constants/PowerQuerySdkConfiguration.ts
+++ b/src/constants/PowerQuerySdkConfiguration.ts
@@ -142,6 +142,15 @@ export const ExtensionConfigurations = {
 
         return result;
     },
+
+    get nugetFeed(): string | undefined {
+        const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
+            ExtensionConstants.ConfigNames.PowerQuerySdk.name,
+        );
+
+        return config.get(ExtensionConstants.ConfigNames.PowerQuerySdk.properties.externalsNugetPath);
+    },
+
     setPQTestLocation(
         pqTestLocation: string | undefined,
         configurationTarget: vscode.ConfigurationTarget | boolean | null = vscode.ConfigurationTarget.Global,

--- a/src/constants/PowerQuerySdkExtension.ts
+++ b/src/constants/PowerQuerySdkExtension.ts
@@ -34,6 +34,7 @@ const ConfigNames = {
             autoDetection: "features.autoDetection" as const,
             externalsMsbuildPath: "externals.msbuildPath" as const,
             externalsNugetPath: "externals.nugetPath" as const,
+            externalsNugetFeed: "externals.nugetFeed" as const,
             pqTestLocation: "tools.location" as const,
             defaultExtensionLocation: "defaultExtension" as const,
             defaultQueryFileLocation: "defaultQueryFile" as const,
@@ -58,7 +59,6 @@ const PowerQueryTaskType: string = PQLanguageId;
 const PQDebugType: string = PowerQueryTaskType;
 
 const NugetBaseFolder: string = ".nuget" as const;
-const NugetConfigFileName: string = "nuget-staging.config" as const;
 const InternalMsftPqSdkToolsNugetName: string = "Microsoft.PowerQuery.SdkTools" as const;
 const PublicMsftPqSdkToolsNugetName: string = InternalMsftPqSdkToolsNugetName;
 const SuggestedPqTestNugetVersion: string = "2.109.5" as const;
@@ -96,7 +96,6 @@ export const ExtensionConstants = Object.freeze({
     PowerQueryTaskType,
     PQDebugType,
     NugetBaseFolder,
-    NugetConfigFileName,
     InternalMsftPqSdkToolsNugetName,
     PublicMsftPqSdkToolsNugetName,
     SuggestedPqTestNugetVersion,

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -37,7 +37,6 @@ export const extensionInstalledDirectory = path.join(
 );
 
 export const NugetBaseFolderName: string = ExtensionConstants.NugetBaseFolder;
-export const NugetConfigFileName: string = ExtensionConstants.NugetConfigFileName;
 
 export const NugetPackagesDirectory: string = path.join(extensionInstalledDirectory, NugetBaseFolderName);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69623692/194382904-ac0ff500-7b64-450d-86aa-afd92e08e90d.png)

- remove hard-coded staging nuget config xml
- replace it with one optional nuget feed url and we need not suggest default value for the item
- this should resolve part of the features requested by the 917170