### PR TITLE
feat. consume optional error object from the test run execution resul…

### DIFF
--- a/webviews/pq-test-result-view/public/i18n/pq-test-result-view.json
+++ b/webviews/pq-test-result-view/public/i18n/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label" : "Close",
+  "common.error.label" : "Error",
   "testBatteryResView.Table.Output.Title" : "Output",
   "testBatteryResView.Table.Output.Summary" : "Summary",
   "testBatteryResView.Table.Output.DataSource" : "DataSource"


### PR DESCRIPTION
feat. consume optional error object from the test run execution result contract object for both newer and older versions

when we were using a newer version:
![image](https://user-images.githubusercontent.com/69623692/194408983-5cc6132a-9125-422f-bc22-307bf0b8fa2a.png)

when we were using an older version:
![image](https://user-images.githubusercontent.com/69623692/194409153-861ad4c8-7e57-46c8-b331-0046cca97be3.png)

they should both consume the error properly from the test execution result


