### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 585: Build ID 381005

### DIFF
--- a/localize/i18n/bg-BG/package.nls.json
+++ b/localize/i18n/bg-BG/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/bg-BG/pq-test-result-view.json
+++ b/localize/i18n/bg-BG/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ca-ES/package.nls.json
+++ b/localize/i18n/ca-ES/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ca-ES/pq-test-result-view.json
+++ b/localize/i18n/ca-ES/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/cs-CZ/package.nls.json
+++ b/localize/i18n/cs-CZ/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/cs-CZ/pq-test-result-view.json
+++ b/localize/i18n/cs-CZ/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/da-DK/package.nls.json
+++ b/localize/i18n/da-DK/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/da-DK/pq-test-result-view.json
+++ b/localize/i18n/da-DK/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/de-DE/package.nls.json
+++ b/localize/i18n/de-DE/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/de-DE/pq-test-result-view.json
+++ b/localize/i18n/de-DE/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/el-GR/package.nls.json
+++ b/localize/i18n/el-GR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/el-GR/pq-test-result-view.json
+++ b/localize/i18n/el-GR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/es-ES/package.nls.json
+++ b/localize/i18n/es-ES/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/es-ES/pq-test-result-view.json
+++ b/localize/i18n/es-ES/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/et-EE/package.nls.json
+++ b/localize/i18n/et-EE/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/et-EE/pq-test-result-view.json
+++ b/localize/i18n/et-EE/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/eu-ES/package.nls.json
+++ b/localize/i18n/eu-ES/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/eu-ES/pq-test-result-view.json
+++ b/localize/i18n/eu-ES/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/fi-FI/package.nls.json
+++ b/localize/i18n/fi-FI/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/fi-FI/pq-test-result-view.json
+++ b/localize/i18n/fi-FI/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/fr-FR/package.nls.json
+++ b/localize/i18n/fr-FR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/fr-FR/pq-test-result-view.json
+++ b/localize/i18n/fr-FR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/gl-ES/package.nls.json
+++ b/localize/i18n/gl-ES/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/gl-ES/pq-test-result-view.json
+++ b/localize/i18n/gl-ES/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/hi-IN/package.nls.json
+++ b/localize/i18n/hi-IN/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/hi-IN/pq-test-result-view.json
+++ b/localize/i18n/hi-IN/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/hr-HR/package.nls.json
+++ b/localize/i18n/hr-HR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/hr-HR/pq-test-result-view.json
+++ b/localize/i18n/hr-HR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/hu-HU/package.nls.json
+++ b/localize/i18n/hu-HU/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/hu-HU/pq-test-result-view.json
+++ b/localize/i18n/hu-HU/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/id-ID/package.nls.json
+++ b/localize/i18n/id-ID/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/id-ID/pq-test-result-view.json
+++ b/localize/i18n/id-ID/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/it-IT/package.nls.json
+++ b/localize/i18n/it-IT/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/it-IT/pq-test-result-view.json
+++ b/localize/i18n/it-IT/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ja-JP/package.nls.json
+++ b/localize/i18n/ja-JP/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ja-JP/pq-test-result-view.json
+++ b/localize/i18n/ja-JP/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/kk-KZ/package.nls.json
+++ b/localize/i18n/kk-KZ/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/kk-KZ/pq-test-result-view.json
+++ b/localize/i18n/kk-KZ/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ko-KR/package.nls.json
+++ b/localize/i18n/ko-KR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ko-KR/pq-test-result-view.json
+++ b/localize/i18n/ko-KR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/lt-LT/package.nls.json
+++ b/localize/i18n/lt-LT/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/lt-LT/pq-test-result-view.json
+++ b/localize/i18n/lt-LT/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/lv-LV/package.nls.json
+++ b/localize/i18n/lv-LV/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/lv-LV/pq-test-result-view.json
+++ b/localize/i18n/lv-LV/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ms-MY/package.nls.json
+++ b/localize/i18n/ms-MY/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ms-MY/pq-test-result-view.json
+++ b/localize/i18n/ms-MY/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/nb-NO/package.nls.json
+++ b/localize/i18n/nb-NO/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/nb-NO/pq-test-result-view.json
+++ b/localize/i18n/nb-NO/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/nl-NL/package.nls.json
+++ b/localize/i18n/nl-NL/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/nl-NL/pq-test-result-view.json
+++ b/localize/i18n/nl-NL/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/pl-PL/package.nls.json
+++ b/localize/i18n/pl-PL/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/pl-PL/pq-test-result-view.json
+++ b/localize/i18n/pl-PL/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/pt-BR/package.nls.json
+++ b/localize/i18n/pt-BR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/pt-BR/pq-test-result-view.json
+++ b/localize/i18n/pt-BR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/pt-PT/package.nls.json
+++ b/localize/i18n/pt-PT/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/pt-PT/pq-test-result-view.json
+++ b/localize/i18n/pt-PT/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ro-RO/package.nls.json
+++ b/localize/i18n/ro-RO/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ro-RO/pq-test-result-view.json
+++ b/localize/i18n/ro-RO/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/ru-RU/package.nls.json
+++ b/localize/i18n/ru-RU/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/ru-RU/pq-test-result-view.json
+++ b/localize/i18n/ru-RU/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/sk-SK/package.nls.json
+++ b/localize/i18n/sk-SK/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/sk-SK/pq-test-result-view.json
+++ b/localize/i18n/sk-SK/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/sl-SI/package.nls.json
+++ b/localize/i18n/sl-SI/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/sl-SI/pq-test-result-view.json
+++ b/localize/i18n/sl-SI/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/sr-Cyrl-RS/package.nls.json
+++ b/localize/i18n/sr-Cyrl-RS/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/sr-Cyrl-RS/pq-test-result-view.json
+++ b/localize/i18n/sr-Cyrl-RS/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/sr-Latn-RS/package.nls.json
+++ b/localize/i18n/sr-Latn-RS/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/sr-Latn-RS/pq-test-result-view.json
+++ b/localize/i18n/sr-Latn-RS/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/sv-SE/package.nls.json
+++ b/localize/i18n/sv-SE/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/sv-SE/pq-test-result-view.json
+++ b/localize/i18n/sv-SE/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/th-TH/package.nls.json
+++ b/localize/i18n/th-TH/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/th-TH/pq-test-result-view.json
+++ b/localize/i18n/th-TH/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/tr-TR/package.nls.json
+++ b/localize/i18n/tr-TR/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/tr-TR/pq-test-result-view.json
+++ b/localize/i18n/tr-TR/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/uk-UA/package.nls.json
+++ b/localize/i18n/uk-UA/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/uk-UA/pq-test-result-view.json
+++ b/localize/i18n/uk-UA/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/vi-VN/package.nls.json
+++ b/localize/i18n/vi-VN/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/vi-VN/pq-test-result-view.json
+++ b/localize/i18n/vi-VN/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/zh-CN/package.nls.json
+++ b/localize/i18n/zh-CN/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/zh-CN/pq-test-result-view.json
+++ b/localize/i18n/zh-CN/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"

--- a/localize/i18n/zh-TW/package.nls.json
+++ b/localize/i18n/zh-TW/package.nls.json
@@ -11,6 +11,7 @@
   "extension.pqtest.TestConnectionCommand.title": "Test connection",
   "extension.pqtest.config.externals.msbuildPath.description": "Local path to msbuild.exe installation folder.",
   "extension.pqtest.config.externals.nugetPath.description": "Local path to nuget.exe installation folder.",
+  "extension.pqtest.config.externals.nugetFeed.description": "Suggested nuget feed URL.",
   "extension.pqtest.config.features.autoDetection.description": "When set to false, the SDK does not try to automatically detect connector workspaces and prompt to create a settings file.",
   "extension.pqtest.config.features.useServiceHost": "Try the new feature using a reusable engine service host other than the command lines",
   "extension.pqtest.config.pqtest.location.description": "Local path to PQTest installation folder.",

--- a/localize/i18n/zh-TW/pq-test-result-view.json
+++ b/localize/i18n/zh-TW/pq-test-result-view.json
@@ -1,5 +1,6 @@
 {
   "common.dismiss.label": "Close",
+  "common.error.label": "Error",
   "testBatteryResView.Table.Output.Title": "Output",
   "testBatteryResView.Table.Output.Summary": "Summary",
   "testBatteryResView.Table.Output.DataSource": "DataSource"


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.