### PR TITLE
enhance PqSdkNugetPackageService

### DIFF
--- a/.pipelines/pr-pipeline.yml
+++ b/.pipelines/pr-pipeline.yml
@@ -11,6 +11,8 @@ pr:
 
 pool:
   vmImage: "windows-latest"
+variables:
+  CI: 'true'
 
 steps:
   - task: NodeTool@0

--- a/src/common/PqSdkNugetPackageService.ts
+++ b/src/common/PqSdkNugetPackageService.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { ExtensionConfigurations } from "../constants/PowerQuerySdkConfiguration";
+import { ExtensionConstants } from "../constants/PowerQuerySdkExtension";
+import { GlobalEventBus } from "../GlobalEventBus";
+import { NugetCommandService } from "./nuget/NugetCommandService";
+import { NugetHttpService } from "./nuget/NugetHttpService";
+import { NugetVersions } from "../utils/NugetVersions";
+import { PqSdkOutputChannel } from "../features/PqSdkOutputChannel";
+
+export class PqSdkNugetPackageService {
+    private readonly nugetHttpService: NugetHttpService;
+    private readonly nugetCommandService: NugetCommandService;
+
+    constructor(
+        readonly vscExtCtx: vscode.ExtensionContext,
+        readonly globalEventBus?: GlobalEventBus,
+        readonly outputChannel?: PqSdkOutputChannel,
+    ) {
+        this.nugetHttpService = new NugetHttpService(globalEventBus, outputChannel);
+        this.nugetCommandService = new NugetCommandService(vscExtCtx, outputChannel);
+    }
+
+    public async findNullableNewPqSdkVersion(): Promise<string | undefined> {
+        let sortedNugetVersions: NugetVersions[];
+
+        if (ExtensionConfigurations.nugetPath) {
+            sortedNugetVersions = (
+                await this.nugetCommandService.getPackageReleasedVersions(
+                    ExtensionConstants.PublicMsftPqSdkToolsNugetName,
+                )
+            ).sort(NugetVersions.compare);
+        } else {
+            // we gonna use http endpoint to query the public feed
+            sortedNugetVersions = (
+                await this.nugetHttpService.getPackageReleasedVersions(ExtensionConstants.PublicMsftPqSdkToolsNugetName)
+            ).versions
+                .map((releasedVersion: string) => NugetVersions.createFromReleasedVersionString(releasedVersion))
+                .sort(NugetVersions.compare);
+        }
+
+        if (sortedNugetVersions.length && !sortedNugetVersions[sortedNugetVersions.length - 1].isZero()) {
+            return sortedNugetVersions[sortedNugetVersions.length - 1].toString();
+        } else {
+            return undefined;
+        }
+    }
+
+    public expectedPqSdkPath(maybeNextVersion: string | undefined): string {
+        return this.nugetCommandService.expectedPackagePath(
+            ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+            maybeNextVersion || ExtensionConstants.SuggestedPqTestNugetVersion,
+        );
+    }
+
+    public nugetPqSdkExistsSync(maybeNextVersion?: string): boolean {
+        const expectedPqTestPath: string = this.expectedPqSdkPath(maybeNextVersion);
+
+        return fs.existsSync(expectedPqTestPath);
+    }
+
+    public async updatePqSdkFromNuget(maybeNextVersion: string | undefined): Promise<string | undefined> {
+        const baseNugetFolder: string = path.resolve(this.vscExtCtx.extensionPath, ExtensionConstants.NugetBaseFolder);
+
+        if (!fs.existsSync(baseNugetFolder)) {
+            fs.mkdirSync(baseNugetFolder);
+        }
+
+        if (ExtensionConfigurations.nugetPath) {
+            return this.nugetCommandService.downloadAndExtractNugetPackage(
+                ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+                maybeNextVersion || ExtensionConstants.SuggestedPqTestNugetVersion,
+            );
+        } else {
+            const pqTestFullPath: string = this.expectedPqSdkPath(maybeNextVersion);
+
+            if (fs.existsSync(pqTestFullPath)) return pqTestFullPath;
+
+            await this.nugetHttpService.downloadAndExtractNugetPackage(
+                ExtensionConstants.PublicMsftPqSdkToolsNugetName,
+                maybeNextVersion ?? ExtensionConstants.SuggestedPqTestNugetVersion,
+                path.join(
+                    baseNugetFolder,
+                    `${ExtensionConstants.PublicMsftPqSdkToolsNugetName}.${
+                        maybeNextVersion || ExtensionConstants.SuggestedPqTestNugetVersion
+                    }`,
+                ),
+            );
+
+            return fs.existsSync(pqTestFullPath) ? pqTestFullPath : undefined;
+        }
+    }
+}

--- a/src/common/PqSdkNugetPackageService.ts
+++ b/src/common/PqSdkNugetPackageService.ts
@@ -29,7 +29,7 @@ export class PqSdkNugetPackageService {
         readonly outputChannel?: PqSdkOutputChannel,
     ) {
         this.nugetHttpService = new NugetHttpService(outputChannel);
-        this.nugetCommandService = new NugetCommandService(vscExtCtx, outputChannel);
+        this.nugetCommandService = new NugetCommandService(vscExtCtx.extensionPath, outputChannel);
 
         this.globalEventBus?.on(
             GlobalEvents.VSCodeEvents.onProxySettingsChanged,
@@ -49,6 +49,8 @@ export class PqSdkNugetPackageService {
         if (ExtensionConfigurations.nugetPath) {
             sortedNugetVersions = (
                 await this.nugetCommandService.getPackageReleasedVersions(
+                    ExtensionConfigurations.nugetPath,
+                    ExtensionConfigurations.nugetFeed,
                     ExtensionConstants.PublicMsftPqSdkToolsNugetName,
                 )
             ).sort(NugetVersions.compare);
@@ -90,6 +92,8 @@ export class PqSdkNugetPackageService {
 
         if (ExtensionConfigurations.nugetPath) {
             return this.nugetCommandService.downloadAndExtractNugetPackage(
+                ExtensionConfigurations.nugetPath,
+                ExtensionConfigurations.nugetFeed,
                 ExtensionConstants.InternalMsftPqSdkToolsNugetName,
                 maybeNextVersion || ExtensionConstants.SuggestedPqTestNugetVersion,
             );

--- a/src/common/nuget/NugetCommandService.ts
+++ b/src/common/nuget/NugetCommandService.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as process from "process";
+import * as vscode from "vscode";
+
+import {
+    ExtensionConfigurations,
+    promptWarningMessageForExternalDependency,
+} from "../../constants/PowerQuerySdkConfiguration";
+import { ExtensionConstants } from "../../constants/PowerQuerySdkExtension";
+import { NugetVersions } from "../../utils/NugetVersions";
+import { PqSdkOutputChannel } from "../../features/PqSdkOutputChannel";
+import { SpawnedProcess } from "../SpawnedProcess";
+
+export class NugetCommandService {
+    constructor(
+        private readonly vscExtCtx: vscode.ExtensionContext,
+        private readonly outputChannel?: PqSdkOutputChannel,
+    ) {}
+
+    get hasNugetPath(): boolean {
+        return Boolean(ExtensionConfigurations.nugetPath);
+    }
+
+    private async doListVersionsFromNugetCmd(
+        packageName: string = ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+        allVersion: boolean = false,
+    ): Promise<string> {
+        await promptWarningMessageForExternalDependency(Boolean(ExtensionConfigurations.nugetPath), true, true);
+
+        const baseNugetFolder: string = path.resolve(this.vscExtCtx.extensionPath, ExtensionConstants.NugetBaseFolder);
+
+        if (!fs.existsSync(baseNugetFolder)) {
+            fs.mkdirSync(baseNugetFolder);
+        }
+
+        const args: string[] = ["list", packageName];
+
+        if (allVersion) {
+            args.push("-AllVersions");
+        }
+
+        if (ExtensionConfigurations.nugetFeed) {
+            args.push("-Source", ExtensionConfigurations.nugetFeed);
+        }
+
+        const command: string = ExtensionConfigurations.nugetPath ?? "nuget";
+
+        this.outputChannel?.appendDebugLine(`Listing nuget packages using nuget.exe`);
+        this.outputChannel?.appendInfoLine(`Running ${command} ${args.join(" ")}`);
+
+        const seizingProcess: SpawnedProcess = new SpawnedProcess(command, args, {
+            cwd: baseNugetFolder,
+            env: {
+                ...process.env,
+                FORCE_NUGET_EXE_INTERACTIVE: "true",
+            },
+        });
+
+        await seizingProcess.deferred$;
+
+        return seizingProcess.stdOut;
+    }
+
+    public expectedPackagePath(
+        packageName: string = ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+        maybeNextVersion: string,
+    ): string {
+        const baseNugetFolder: string = path.resolve(this.vscExtCtx.extensionPath, ExtensionConstants.NugetBaseFolder);
+
+        const pqTestSubPath: string[] = ExtensionConstants.buildNugetPackageSubPath(packageName, maybeNextVersion);
+
+        return path.resolve(baseNugetFolder, ...pqTestSubPath);
+    }
+
+    private async doSeizeFromNugetCmd(
+        packageName: string = ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+        nextVersion: string,
+        baseNugetFolder: string = path.resolve(this.vscExtCtx.extensionPath, ExtensionConstants.NugetBaseFolder),
+    ): Promise<string | undefined> {
+        // use nuget.exe to check the configured feed location
+        await promptWarningMessageForExternalDependency(Boolean(ExtensionConfigurations.nugetPath), true, true);
+
+        const pqTestFullPath: string = this.expectedPackagePath(packageName, nextVersion);
+
+        if (!fs.existsSync(baseNugetFolder)) {
+            fs.mkdirSync(baseNugetFolder);
+        }
+
+        const args: string[] = [
+            "install",
+            ExtensionConstants.InternalMsftPqSdkToolsNugetName,
+            "-Version",
+            nextVersion,
+            "-OutputDirectory",
+            baseNugetFolder,
+        ];
+
+        if (ExtensionConfigurations.nugetFeed) {
+            args.push("-Source", ExtensionConfigurations.nugetFeed);
+        }
+
+        const command: string = ExtensionConfigurations.nugetPath ?? "nuget";
+
+        this.outputChannel?.appendDebugLine(`Installing nuget packages using nuget.exe`);
+        this.outputChannel?.appendInfoLine(`Running ${command} ${args.join(" ")}`);
+
+        const seizingProcess: SpawnedProcess = new SpawnedProcess(
+            command,
+            args,
+            {
+                cwd: baseNugetFolder,
+                env: {
+                    ...process.env,
+                    FORCE_NUGET_EXE_INTERACTIVE: "true",
+                },
+            },
+            {
+                onStdOut: (data: Buffer): void => {
+                    this.outputChannel?.appendInfoLine(data.toString("utf8"));
+                },
+                onStdErr: (data: Buffer): void => {
+                    this.outputChannel?.appendErrorLine(data.toString("utf8"));
+                },
+            },
+        );
+
+        await seizingProcess.deferred$;
+
+        return fs.existsSync(pqTestFullPath) ? pqTestFullPath : undefined;
+    }
+
+    public async getPackageReleasedVersions(packageName: string): Promise<NugetVersions[]> {
+        return NugetVersions.createFromNugetListAllOutput(await this.doListVersionsFromNugetCmd(packageName, true));
+    }
+
+    public downloadAndExtractNugetPackage(packageName: string, packageVersion: string): Promise<string | undefined> {
+        return this.doSeizeFromNugetCmd(packageName, packageVersion);
+    }
+}

--- a/src/common/nuget/NugetHttpService.ts
+++ b/src/common/nuget/NugetHttpService.ts
@@ -14,12 +14,12 @@ import { promisify } from "util";
 import { StreamZipAsync } from "node-stream-zip";
 
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { GlobalEventBus, GlobalEvents } from "../GlobalEventBus";
-import { debounce } from "../utils/debounce";
-import { ExtensionConfigurations } from "../constants/PowerQuerySdkConfiguration";
-import { makeOneTmpDir } from "../utils/osUtils";
-import { PqSdkOutputChannel } from "../features/PqSdkOutputChannel";
-import { removeDirectoryRecursively } from "../utils/files";
+import { GlobalEventBus, GlobalEvents } from "../../GlobalEventBus";
+import { debounce } from "../../utils/debounce";
+import { ExtensionConfigurations } from "../../constants/PowerQuerySdkConfiguration";
+import { makeOneTmpDir } from "../../utils/osUtils";
+import { PqSdkOutputChannel } from "../../features/PqSdkOutputChannel";
+import { removeDirectoryRecursively } from "../../utils/files";
 
 const streamFinished$deferred: (
     stream: NodeJS.ReadStream | NodeJS.WritableStream | NodeJS.ReadWriteStream,

--- a/src/constants/PowerQuerySdkExtension.ts
+++ b/src/constants/PowerQuerySdkExtension.ts
@@ -71,8 +71,8 @@ const PqTestSubPath: string[] = [
 
 const MakePQXExecutableName: string = "MakePQX.exe" as const;
 
-function buildPqTestSubPath(pqTestVersion: string): string[] {
-    return [`${InternalMsftPqSdkToolsNugetName}.${pqTestVersion}`, "tools", "PQTest.exe"];
+function buildNugetPackageSubPath(packageName: string, version: string): string[] {
+    return [`${packageName}.${version}`, "tools", "PQTest.exe"];
 }
 
 const NugetDownloadUrl: string = "https://www.nuget.org/downloads" as const;
@@ -101,7 +101,7 @@ export const ExtensionConstants = Object.freeze({
     SuggestedPqTestNugetVersion,
     PqTestSubPath,
     MakePQXExecutableName,
-    buildPqTestSubPath,
+    buildNugetPackageSubPath,
     ConfigNames,
     NugetDownloadUrl,
     MSBuildDownloadUrl,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,8 +17,8 @@ import { IDisposable } from "./common/Disposable";
 import { isSupportedOs } from "./utils/osUtils";
 import { LifecycleCommands } from "./commands/LifecycleCommands";
 import { LifeCycleTaskTreeView } from "./features/LifeCycleTaskTreeView";
-import { NugetHttpService } from "./common/NugetHttpService";
 import { PowerQueryTaskProvider } from "./features/PowerQueryTaskProvider";
+import { PqSdkNugetPackageService } from "./common/PqSdkNugetPackageService";
 import { PqSdkOutputChannel } from "./features/PqSdkOutputChannel";
 import { PqServiceHostClient } from "./pqTestConnector/PqServiceHostClient";
 import { PqTestExecutableTaskQueue } from "./pqTestConnector/PqTestExecutableTaskQueue";
@@ -38,7 +38,12 @@ export function activate(vscExtCtx: vscode.ExtensionContext): void {
         const globalEventBus: GlobalEventBus = new GlobalEventBus(vscExtCtx);
         const pqTestResultViewPanelDisposable: IDisposable = PqTestResultViewPanel.activate(vscExtCtx);
         const pqSdkOutputChannel: PqSdkOutputChannel = new PqSdkOutputChannel();
-        const nugetHttpService: NugetHttpService = new NugetHttpService(globalEventBus, pqSdkOutputChannel);
+
+        const pqSdkNugetPackageService: PqSdkNugetPackageService = new PqSdkNugetPackageService(
+            vscExtCtx,
+            globalEventBus,
+            pqSdkOutputChannel,
+        );
 
         const disposablePqTestServices: IPQTestService & IDisposable = useServiceHost
             ? new PqServiceHostClient(globalEventBus, pqSdkOutputChannel)
@@ -65,7 +70,7 @@ export function activate(vscExtCtx: vscode.ExtensionContext): void {
         const lifecycleCommands: LifecycleCommands = new LifecycleCommands(
             vscExtCtx,
             globalEventBus,
-            nugetHttpService,
+            pqSdkNugetPackageService,
             disposablePqTestServices,
             pqSdkOutputChannel,
         );

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -41,6 +41,7 @@ export const NugetBaseFolderName: string = ExtensionConstants.NugetBaseFolder;
 export const NugetPackagesDirectory: string = path.join(extensionInstalledDirectory, NugetBaseFolderName);
 
 export const PqTestSubPath: string[] = ExtensionConstants.PqTestSubPath;
-export const buildPqTestSubPath: (version: string) => string[] = ExtensionConstants.buildPqTestSubPath;
+export const buildPqSdkSubPath: (version: string) => string[] = (version: string) =>
+    ExtensionConstants.buildNugetPackageSubPath(ExtensionConstants.InternalMsftPqSdkToolsNugetName, version);
 
 export const PublicMsftPqSdkToolsNugetName: string = ExtensionConstants.PublicMsftPqSdkToolsNugetName;

--- a/src/test/utils/pqSdkNugetPackageUtils.ts
+++ b/src/test/utils/pqSdkNugetPackageUtils.ts
@@ -11,7 +11,7 @@ import * as path from "path";
 
 import {
     AWAIT_INTERVAL,
-    buildPqTestSubPath,
+    buildPqSdkSubPath,
     MAX_AWAIT_TIME,
     NugetPackagesDirectory,
     PqTestSubPath,
@@ -30,7 +30,7 @@ export module PqSdkNugetPackages {
     let latestPQSdkNugetVersion: NugetVersions | undefined = undefined;
 
     export function getExpectedPqSdkToolPath(maybeNextVersion?: string): string | undefined {
-        const pqTestSubPath: string[] = maybeNextVersion ? buildPqTestSubPath(maybeNextVersion) : PqTestSubPath;
+        const pqTestSubPath: string[] = maybeNextVersion ? buildPqSdkSubPath(maybeNextVersion) : PqTestSubPath;
 
         return path.resolve(NugetPackagesDirectory, ...pqTestSubPath);
     }

--- a/src/utils/NugetVersions.ts
+++ b/src/utils/NugetVersions.ts
@@ -35,6 +35,34 @@ export class NugetVersions {
     }
 
     /**
+     * create NugetVersions from the std output like:
+     * MSBuild auto-detection: using msbuild version '*****' from '\Microsoft Visual Studio\2019\*****\MSBuild\Current\Bin'.
+     * Microsoft.PowerQuery.SdkTools 2.110.3
+     * Microsoft.PowerQuery.SdkTools 2.110.2
+     * Microsoft.PowerQuery.SdkTools 2.109.6
+     * Microsoft.PowerQuery.SdkTools 2.107.1
+     * @param stdOutput
+     */
+    public static createFromNugetListAllOutput(stdOutput: string): NugetVersions[] {
+        const result: NugetVersions[] = [];
+
+        if (!stdOutput) return result;
+
+        NugetStdOutputOfVersionRegExp.lastIndex = 0;
+        let matched: RegExpMatchArray | null = NugetStdOutputOfVersionRegExp.exec(stdOutput);
+
+        while (matched && matched.length === 5) {
+            result.push(
+                new NugetVersions(parseInt(matched[2], 10), parseInt(matched[3], 10), parseInt(matched[4], 10)),
+            );
+
+            matched = NugetStdOutputOfVersionRegExp.exec(stdOutput);
+        }
+
+        return result;
+    }
+
+    /**
      * create NugetVersion from a path like:
      * .\vscode-powerquery-sdk\.nuget\Microsoft.PowerQuery.SdkTools.2.107.1\tools\..
      * @param fullPath

--- a/unit-tests/common/nuget/NugetCommandService.spec.ts
+++ b/unit-tests/common/nuget/NugetCommandService.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as chai from "chai";
+import * as fs from "fs";
+import * as path from "path";
+
+import { findExecutable } from "../../../src/utils/executables";
+import { makeOneTmpDir } from "../../../src/utils/osUtils";
+import { NugetCommandService } from "../../../src/common/nuget/NugetCommandService";
+import { removeDirectoryRecursively } from "../../../src/utils/files";
+
+const expect = chai.expect;
+const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
+const InternalNugetFeed = "https://powerbi.pkgs.visualstudio.com/_packaging/PowerBiComponents/nuget/v3/index.json";
+
+describe("NugetCommandService unit testes", () => {
+    const nugetPath = findExecutable("nuget", [".exe", ""]);
+
+    if (nugetPath) {
+        let oneTmpDir: string;
+        let nugetCommandService: NugetCommandService;
+
+        before(() => {
+            oneTmpDir = makeOneTmpDir();
+            nugetCommandService = new NugetCommandService(oneTmpDir);
+        });
+
+        it("getPackageReleasedVersions v1", async () => {
+            const res = await nugetCommandService.getPackageReleasedVersions(
+                nugetPath,
+                InternalNugetFeed,
+                SdkPackageName,
+            );
+
+            expect(res.length).gt(1);
+        }).timeout(3e4);
+
+        it("downloadAndExtractNugetPackage v1", async () => {
+            const res = await nugetCommandService.getPackageReleasedVersions(
+                nugetPath,
+                InternalNugetFeed,
+                SdkPackageName,
+            );
+
+            expect(res.length).gt(1);
+            const theVersion = res[0];
+            const theVersionStr = theVersion.toString();
+
+            await nugetCommandService.downloadAndExtractNugetPackage(
+                nugetPath,
+                InternalNugetFeed,
+                SdkPackageName,
+                theVersionStr,
+            );
+
+            expect(
+                fs.existsSync(
+                    path.resolve(
+                        oneTmpDir,
+                        ".nuget",
+                        `${SdkPackageName}.${theVersionStr}`,
+                        `Microsoft.PowerQuery.SdkTools.${theVersionStr}.nupkg`,
+                    ),
+                ),
+            ).true;
+
+            expect(
+                fs.existsSync(
+                    path.resolve(oneTmpDir, ".nuget", `${SdkPackageName}.${theVersionStr}`, "tools", "PQTest.exe"),
+                ),
+            ).true;
+
+            await removeDirectoryRecursively(oneTmpDir);
+        }).timeout(9e4);
+
+        after(() => {
+            setTimeout(() => {
+                if (oneTmpDir) {
+                    void removeDirectoryRecursively(oneTmpDir);
+                    oneTmpDir = "";
+                }
+            }, 25);
+        });
+    }
+});

--- a/unit-tests/common/nuget/NugetCommandService.spec.ts
+++ b/unit-tests/common/nuget/NugetCommandService.spec.ts
@@ -21,7 +21,8 @@ const InternalNugetFeed = "https://powerbi.pkgs.visualstudio.com/_packaging/Powe
 describe("NugetCommandService unit testes", () => {
     const nugetPath = findExecutable("nuget", [".exe", ""]);
 
-    if (nugetPath) {
+    // disable these test cases for the ci due to auth config
+    if (nugetPath && process.env.CI !== "true") {
         let oneTmpDir: string;
         let nugetCommandService: NugetCommandService;
 

--- a/unit-tests/common/nuget/NugetHttpService.spec.ts
+++ b/unit-tests/common/nuget/NugetHttpService.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as chai from "chai";
+import * as fs from "fs";
+import * as path from "path";
+
+import { makeOneTmpDir } from "../../../src/utils/osUtils";
+import { NugetHttpService } from "../../../src/common/nuget/NugetHttpService";
+import { removeDirectoryRecursively } from "../../../src/utils/files";
+
+const expect = chai.expect;
+const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
+
+describe("NugetHttpService unit testes", () => {
+    const nugetHttpService = new NugetHttpService();
+
+    it("getPackageReleasedVersions v1", async () => {
+        const res = await nugetHttpService.getPackageReleasedVersions(SdkPackageName);
+        expect(res.versions.length).gt(1);
+    }).timeout(3e4);
+
+    it("downloadAndExtractNugetPackage v1", async () => {
+        const oneTmpDir = makeOneTmpDir();
+        const res = await nugetHttpService.getPackageReleasedVersions(SdkPackageName);
+        expect(res.versions.length).gt(1);
+        const theVersion = res.versions[res.versions.length - 1];
+        await nugetHttpService.downloadAndExtractNugetPackage(SdkPackageName, theVersion, oneTmpDir);
+
+        expect(fs.existsSync(path.resolve(oneTmpDir, "Microsoft.PowerQuery.SdkTools.nuspec"))).true;
+        expect(fs.existsSync(path.resolve(oneTmpDir, "tools", "PQTest.exe"))).true;
+
+        await removeDirectoryRecursively(oneTmpDir);
+    }).timeout(3e4);
+});


### PR DESCRIPTION
- create PqSdkNugetPackageService.ts and remove PqSdk relating codes out of LifecycleCommands.ts for the better readability; and i still thought it would be much better to avoid inherit PqSdkNugetPackageService from lifecycleCommand
- create unit tests for it associated NugetCommandService and NugetHttpService