### PR TITLE
fix service host error message

### DIFF
--- a/webviews/pq-test-result-view/src/views/TestBatteryResultView.tsx
+++ b/webviews/pq-test-result-view/src/views/TestBatteryResultView.tsx
@@ -39,7 +39,7 @@ export const TestBatteryResultView: React.FC<TestBatteryResult> = React.memo<Tes
     );
 
     const errorDetailsString = useMemo<string | null>(() => {
-        if (testRunExecution.Status !== "Passed") {
+        if (testRunExecution.Status !== "Passed" && testRunExecution.Status !== 3) {
             if (testRunExecution.Error?.Message && typeof testRunExecution.Error?.Message === "string") {
                 return testRunExecution.Error?.Message;
             }


### PR DESCRIPTION
service host return enumeration by value other than labels, it caused falsely error message keep showing up, thus let's use this minor fix as a workaround before the next incoming service host.