### PR TITLE
Don't include authenticationKind option when setting a credential with template

### DIFF
--- a/src/pqTestConnector/PqServiceHostClient.ts
+++ b/src/pqTestConnector/PqServiceHostClient.ts
@@ -779,6 +779,7 @@ export class PqServiceHostClient implements IPQTestService, IDisposable {
                         PathToConnector: createAuthState.PathToConnectorFile || getFirstWorkspaceFolder()?.uri.fsPath,
                         PathToQueryFile: resolveSubstitutedValues(createAuthState.PathToQueryFile),
                         // DataSourceKind: createAuthState.DataSourceKind,
+                        // TODO: We might need to remove this arg when the service host command matches pqtest
                         AuthenticationKind: createAuthState.AuthenticationKind,
                         TemplateValueKey: createAuthState.$$KEY$$,
                         TemplateValueUsername: createAuthState.$$USERNAME$$,

--- a/src/pqTestConnector/PqTestExecutableTaskQueue.ts
+++ b/src/pqTestConnector/PqTestExecutableTaskQueue.ts
@@ -535,14 +535,7 @@ export class PqTestExecutableTaskQueue implements IPQTestService, IDisposable {
                 "Permissions": []
             }`;
             /* eslint-enable*/
-        } else if (theAuthKind.toLowerCase() === "oauth") {
-            payloadStr = `{
-                "AuthenticationKind": "OAuth",
-                "AuthenticationProperties": {},
-                "PrivacySetting": "None",
-                "Permissions": []
-            }`;
-
+        } else if (theAuthKind.toLowerCase() === "oauth" || theAuthKind.toLowerCase() === "aad") {
             additionalArgs.unshift("--interactive");
         } else if (theAuthKind.toLowerCase() === "implicit" || theAuthKind.toLowerCase() === "anonymous") {
             theAuthKind = "Anonymous";
@@ -560,21 +553,13 @@ export class PqTestExecutableTaskQueue implements IPQTestService, IDisposable {
                 "PrivacySetting": "None",
                 "Permissions": []
             }`;
-        } else if (theAuthKind.toLowerCase() === "aad") {
-            payloadStr = `{
-                "AuthenticationKind": "Aad",
-                "AuthenticationProperties": {},
-                "PrivacySetting": "None",
-                "Permissions": []
-            }`;
-
-            additionalArgs.unshift("--interactive");
         }
 
-        additionalArgs.unshift(`${theAuthKind}`);
-        additionalArgs.unshift(`-ak`);
-
-        // additionalArgs.unshift(`-dsk=${createAuthState.DataSourceKind}`);
+        if (payloadStr === undefined) {
+            // AuthenticationKind must be specified if it's not provided in the json input
+            additionalArgs.unshift(`${theAuthKind}`);
+            additionalArgs.unshift(`-ak`);
+        }
 
         // in case latter we turn additionalArgs an empty array, we should set it undefined at that moment
         if (Array.isArray(additionalArgs) && additionalArgs.length === 0) {

--- a/src/test/connectors/AadTestConnector/.vscode/settings.json
+++ b/src/test/connectors/AadTestConnector/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "powerquery.sdk.pqtest.queryFile": "${workspaceFolder}\\${workspaceFolderBasename}.query.pq",
-  "powerquery.sdk.pqtest.extension": "${workspaceFolder}\\bin\\AnyCPU\\Debug\\${workspaceFolderBasename}.mez"
+  "powerquery.sdk.defaultQueryFile": "${workspaceFolder}\\${workspaceFolderBasename}.query.pq",
+  "powerquery.sdk.defaultExtension": "${workspaceFolder}\\bin\\AnyCPU\\Debug\\${workspaceFolderBasename}.mez"
 }


### PR DESCRIPTION
The `-ak` option is only needed when a credential isn't being set via credential template. This change is required for compatibility with the 2.111.x version of the SdkTools. 

Related to #157 