### PR TITLE
fix. "Run TestConnection function" not rebuilding extension package file

### DIFF
--- a/src/pqTestConnector/PqServiceHostClient.ts
+++ b/src/pqTestConnector/PqServiceHostClient.ts
@@ -794,8 +794,11 @@ export class PqServiceHostClient implements IPQTestService, IDisposable {
         }
     }
 
-    TestConnection(): Promise<GenericResult> {
+    async TestConnection(): Promise<GenericResult> {
         if (this.serverTransportTuple) {
+            // maybe we need to execute the build task before evaluating.
+            await this.ExecuteBuildTaskAndAwaitIfNeeded();
+
             const theRequestMessage: PqServiceHostRequest = {
                 jsonrpc: JSON_RPC_VERSION,
                 id: this.nextSequenceId,

--- a/src/pqTestConnector/PqTestExecutableTaskQueue.ts
+++ b/src/pqTestConnector/PqTestExecutableTaskQueue.ts
@@ -613,7 +613,10 @@ export class PqTestExecutableTaskQueue implements IPQTestService, IDisposable {
         });
     }
 
-    public TestConnection(): Promise<GenericResult> {
+    public async TestConnection(): Promise<GenericResult> {
+        // maybe we need to execute the build task before evaluating.
+        await this.ExecuteBuildTaskAndAwaitIfNeeded();
+
         return this.doEnqueueOneTask<GenericResult>({
             operation: "test-connection",
             pathToConnector: resolveSubstitutedValues(ExtensionConfigurations.DefaultExtensionLocation),


### PR DESCRIPTION
The .mez file to be rebuilt, when needed, prior to the actual TestConnection test being run
And it would align "Run TestConnection function"'s behavior with how "Evaluate current file" behaves.