### PR TITLE
fix. msrc 75494 switch the debug adapter to use a named pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,14 +298,14 @@
                     {
                         "type": "powerquery",
                         "request": "launch",
-                        "name": "%extension.pqtest.initialConfigurations.name%",
+                        "name": "Evaluate power query file.",
                         "program": "${workspaceFolder}/${command:AskForPowerQueryFileName}"
                     }
                 ],
                 "configurationSnippets": [
                     {
                         "label": "powerquery Debug: Launch",
-                        "description": "%extension.pqtest.configurationSnippets.description%",
+                        "description": "A new configuration for testing power query file a user selected.",
                         "body": {
                             "type": "powerquery",
                             "request": "launch",

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,7 +28,5 @@
     "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
     "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
     "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
-    "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection",
-    "extension.pqtest.initialConfigurations.name": "Evaluate power query file.",
-    "extension.pqtest.configurationSnippets.description": "A new configuration for testing power query file a user selected."
+    "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection"
 }


### PR DESCRIPTION
- fix. msrc 75494 switch the debug adapter to use a named pipeline
- the initialConfigurations and configurationSnippets don't but nls strings, thus remove them

https://user-images.githubusercontent.com/69623692/205018836-c80a9b45-3ffc-475f-aef4-c36828dce71c.mp4


