### PR TITLE
fix. try to support ado onebranch, which might lock intermediate file…

### DIFF
--- a/src/test/commonSuite/NewProject.spec.ts
+++ b/src/test/commonSuite/NewProject.spec.ts
@@ -22,7 +22,7 @@ import {
 
 import { delay } from "../../utils/pids";
 import { makeOneTmpDir } from "../../utils/osUtils";
-import { removeDirectoryRecursively } from "../../utils/files";
+import { tryRemoveDirectoryRecursively } from "../../utils/files";
 
 const expect = chai.expect;
 
@@ -93,7 +93,7 @@ describe("New extension project Tests", () => {
 
         after(() => {
             if (oneTmpDir) {
-                void removeDirectoryRecursively(oneTmpDir);
+                void tryRemoveDirectoryRecursively(oneTmpDir);
                 oneTmpDir = undefined;
             }
         });
@@ -165,7 +165,7 @@ describe("New extension project Tests", () => {
 
         after(() => {
             if (oneTmpDir) {
-                void removeDirectoryRecursively(oneTmpDir);
+                void tryRemoveDirectoryRecursively(oneTmpDir);
                 oneTmpDir = undefined;
             }
         });

--- a/src/test/utils/NugetLiteHttpService.ts
+++ b/src/test/utils/NugetLiteHttpService.ts
@@ -15,7 +15,7 @@ import { StreamZipAsync } from "node-stream-zip";
 
 import axios, { AxiosInstance, AxiosResponse } from "axios";
 import { makeOneTmpDir } from "../../utils/osUtils";
-import { removeDirectoryRecursively } from "../../utils/files";
+import { tryRemoveDirectoryRecursively } from "../../utils/files";
 
 const streamFinished$deferred: (
     stream: NodeJS.ReadStream | NodeJS.WritableStream | NodeJS.ReadWriteStream,
@@ -93,6 +93,6 @@ export class NugetLiteHttpService {
         await zip.extract(null, outputLocation);
         await zip.close();
 
-        await removeDirectoryRecursively(oneTmpDir);
+        await tryRemoveDirectoryRecursively(oneTmpDir);
     }
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -45,6 +45,15 @@ export function removeDirectoryRecursively(directoryFullName: string): Promise<v
     });
 }
 
+export function tryRemoveDirectoryRecursively(directoryFullName: string): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new Promise<void>((resolve: () => void, _reject: (reason?: any) => void) => {
+        fs.rm(directoryFullName, { recursive: true, force: true }, (_err: NodeJS.ErrnoException | null) => {
+            resolve();
+        });
+    });
+}
+
 export function getCtimeOfAFile(fileFullPath: string): Date {
     if (fs.existsSync(fileFullPath)) {
         const fileStats: fs.Stats = fs.statSync(fileFullPath);

--- a/unit-tests/common/Utils.spec.ts
+++ b/unit-tests/common/Utils.spec.ts
@@ -9,7 +9,7 @@ import * as chai from "chai";
 import * as fs from "fs";
 
 import { makeOneTmpDir } from "../../src/utils/osUtils";
-import { removeDirectoryRecursively } from "../../src/utils/files";
+import { tryRemoveDirectoryRecursively } from "../../src/utils/files";
 
 const expect = chai.expect;
 
@@ -19,6 +19,6 @@ describe("Utils unit testes", () => {
 
         expect(fs.existsSync(oneTmpDir)).true;
 
-        await removeDirectoryRecursively(oneTmpDir);
+        await tryRemoveDirectoryRecursively(oneTmpDir);
     });
 });

--- a/unit-tests/common/nuget/NugetCommandService.spec.ts
+++ b/unit-tests/common/nuget/NugetCommandService.spec.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 import { findExecutable } from "../../../src/utils/executables";
 import { makeOneTmpDir } from "../../../src/utils/osUtils";
 import { NugetCommandService } from "../../../src/common/nuget/NugetCommandService";
-import { removeDirectoryRecursively } from "../../../src/utils/files";
+import { tryRemoveDirectoryRecursively } from "../../../src/utils/files";
 
 const expect = chai.expect;
 const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
@@ -76,13 +76,13 @@ describe("NugetCommandService unit testes", () => {
                 ),
             ).true;
 
-            await removeDirectoryRecursively(oneTmpDir);
+            await tryRemoveDirectoryRecursively(oneTmpDir);
         }).timeout(9e4);
 
         after(() => {
             setTimeout(() => {
                 if (oneTmpDir) {
-                    void removeDirectoryRecursively(oneTmpDir);
+                    void tryRemoveDirectoryRecursively(oneTmpDir);
                     oneTmpDir = "";
                 }
             }, 25);

--- a/unit-tests/common/nuget/NugetHttpService.spec.ts
+++ b/unit-tests/common/nuget/NugetHttpService.spec.ts
@@ -11,7 +11,7 @@ import * as path from "path";
 
 import { makeOneTmpDir } from "../../../src/utils/osUtils";
 import { NugetHttpService } from "../../../src/common/nuget/NugetHttpService";
-import { removeDirectoryRecursively } from "../../../src/utils/files";
+import { tryRemoveDirectoryRecursively } from "../../../src/utils/files";
 
 const expect = chai.expect;
 const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
@@ -34,6 +34,6 @@ describe("NugetHttpService unit testes", () => {
         expect(fs.existsSync(path.resolve(oneTmpDir, "Microsoft.PowerQuery.SdkTools.nuspec"))).true;
         expect(fs.existsSync(path.resolve(oneTmpDir, "tools", "PQTest.exe"))).true;
 
-        await removeDirectoryRecursively(oneTmpDir);
+        await tryRemoveDirectoryRecursively(oneTmpDir);
     }).timeout(3e4);
 });


### PR DESCRIPTION
Onebranch might watch files from time to time, thus os would block us removing files. 
Thus, in our test cases, we have to tryRemove and eat any exceptions popped up.