### PR TITLE
fix. add a missing i18n string

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -29,5 +29,6 @@
     "extension.pqtest.debugger.properties.operation.description": "PQTest operation string",
     "extension.pqtest.debugger.properties.operation.info.description": "info: Returns all module information",
     "extension.pqtest.debugger.properties.operation.runTest.description": "run-test: test connection",
-    "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test current connection"
+    "extension.pqtest.debugger.properties.operation.testConnection.description": "test-connection: test the connection of current connector",
+    "extension.pqtest.debugger.properties.additionalArgs.description": "Additional arguments for the debugging task"
 }


### PR DESCRIPTION
fix. add a missing i18n string: extension.pqtest.debugger.properties.additionalArgs.description

my bad, I forgot one i18n string, and super thank to Matt for finding it.