### PR TITLE
fix. template files should use UTF8 encoding other than UTF8 BOM

### DIFF
--- a/templates/PQConn.pq
+++ b/templates/PQConn.pq
@@ -1,4 +1,4 @@
-﻿// This file contains your Data Connector logic
+// This file contains your Data Connector logic
 [Version = "1.0.0"]
 section {{ProjectName}};
 

--- a/templates/PQConn.proj
+++ b/templates/PQConn.proj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="BuildMez">
   <PropertyGroup>
     <OutputPath Condition="'$(OutputPath)' == ''">$(MSBuildProjectDirectory)\bin\</OutputPath>

--- a/templates/PQConn.query.pq
+++ b/templates/PQConn.query.pq
@@ -1,4 +1,4 @@
-﻿// Use this file to write queries to test your data connector
+// Use this file to write queries to test your data connector
 let
     result = {{ProjectName}}.Contents()
 in


### PR DESCRIPTION
Template files should be encoded in UTF8 other than UTF8 w/ BOM.

UTF8-BOM would prefix a zero width no-break space, 0xEF 0xBB 0xBF, at the beginning of the file for editors to more reliably to tell whether the file is encoded in UTF8 or not.
https://www.compart.com/en/unicode/U+FEFF

And it would cause problem when we need to directly handle the whole file over to the parser. Either we have to trim white spaces manually or we have to tell whether file is encoded of BOM.

So, I suggested encode all files in UTF8 by default for simplicity. 