### PR TITLE
Fix onModuleLibraryUpdated call

### DIFF
--- a/src/common/vscode-powerquery.api.d.ts
+++ b/src/common/vscode-powerquery.api.d.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+// Must be kept in sync with vscode-powerquery extension API.
+// https://github.com/microsoft/vscode-powerquery/blob/master/client/src/vscode-powerquery.api.d.ts
+// TODO: Add a way to import API as npm module or sync from original code base.
+
+// The JSON output of a localized standard library.
+export type LibraryJson = ReadonlyArray<LibraryExportJson>;
+
+export interface LibraryExportJson {
+    readonly name: string;
+    readonly documentation: LibraryDocumentationJson | null;
+    readonly functionParameters: ReadonlyArray<LibraryFunctionParameterJson> | null;
+    readonly completionItemKind: number;
+    readonly isDataSource: boolean;
+    readonly type: string;
+}
+
+export interface LibraryDocumentationJson {
+    readonly description: string | null;
+    readonly longDescription: string | null;
+}
+
+export interface LibraryFunctionParameterJson {
+    readonly name: string;
+    readonly type: string;
+    readonly isRequired: boolean;
+    readonly isNullable: boolean;
+    readonly caption: string | null;
+    readonly description: string | null;
+    readonly sampleValues: ReadonlyArray<string | number> | null;
+    readonly allowedValues: ReadonlyArray<string | number> | null;
+    readonly defaultValue: string | number | null;
+    readonly fields: ReadonlyArray<LibraryFieldJson> | null;
+    readonly enumNames: ReadonlyArray<string> | null;
+    readonly enumCaptions: ReadonlyArray<string> | ReadonlyArray<null> | null;
+}
+
+export interface LibraryFieldJson {
+    readonly name: string;
+    readonly type: string;
+    readonly isRequired: boolean;
+    readonly caption: string | null;
+    readonly description: string | null;
+}
+
+export interface PowerQueryApi {
+    readonly onModuleLibraryUpdated: (workspaceUriPath: string, library: LibraryJson) => void;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,8 @@
 
 import * as vscode from "vscode";
 
+import * as PQLSExt from "./common/vscode-powerquery.api.d";
+
 import { convertExtensionInfoToLibraryJson, ExtensionInfo, IPQTestService } from "./common/PQTestService";
 import { getFirstWorkspaceFolder, maybeHandleNewWorkspaceCreated } from "./utils/vscodes";
 import { activateMQueryDebug } from "./debugAdaptor/activateMQueryDebug";
@@ -22,10 +24,12 @@ import { PqSdkOutputChannel } from "./features/PqSdkOutputChannel";
 import { PqServiceHostClient } from "./pqTestConnector/PqServiceHostClient";
 import { PqTestExecutableTaskQueue } from "./pqTestConnector/PqTestExecutableTaskQueue";
 import { PqTestResultViewPanel } from "./panels/PqTestResultViewPanel";
+import { stringifyJson } from "./utils/strings";
 
 export function activate(vscExtCtx: vscode.ExtensionContext): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const vscPowerQuery: any = vscode.extensions.getExtension(ExtensionConstants.PQLanguageServiceExtensionId)?.exports;
+    const vscPowerQuery: PQLSExt.PowerQueryApi = vscode.extensions.getExtension(
+        ExtensionConstants.PQLanguageServiceExtensionId,
+    )?.exports;
 
     const useServiceHost: boolean = ExtensionConfigurations.featureUseServiceHost;
 
@@ -51,7 +55,9 @@ export function activate(vscExtCtx: vscode.ExtensionContext): void {
         const theUri: vscode.Uri | undefined = getFirstWorkspaceFolder()?.uri;
 
         if (theUri) {
-            vscPowerQuery.onModuleLibraryUpdated(theUri.toString(), convertExtensionInfoToLibraryJson(infos));
+            const libraryExports: PQLSExt.LibraryJson = convertExtensionInfoToLibraryJson(infos);
+            pqSdkOutputChannel?.appendDebugLine(`onModuleLibraryUpdated: ${stringifyJson(libraryExports)}`);
+            vscPowerQuery.onModuleLibraryUpdated(theUri.toString(), libraryExports);
         }
     });
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -30,4 +30,6 @@ suite("Extension Test Suite", () => {
             assert.equal(languageServiceExtension.isActive, true, "Language service extension failed to activate");
         });
     });
+
+    // TODO: Add onModuleLibraryUpdated test when language service extension returns a result that can be validated.
 });


### PR DESCRIPTION
Fixes `onModuleLibraryUpdated` call ( #311 )

The language service extension made some changes to its input format which broke the SDK because we're not using strictly typed calls.

I copied an updated .d.ts file from the vscode-powerquery repo and will submit a matching change there. 