### PR TITLE
fix. use mtime instead of ctime as ctime keeps changes

### DIFF
--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -44,7 +44,7 @@ import { prettifyJson, resolveTemplateSubstitutedValues } from "../utils/strings
 import { debounce } from "../utils/debounce";
 import { ExtensionConfigurations } from "../constants/PowerQuerySdkConfiguration";
 import { ExtensionConstants } from "../constants/PowerQuerySdkExtension";
-import { getCtimeOfAFile } from "../utils/files";
+import { getMtimeOfAFile } from "../utils/files";
 import { IDisposable } from "../common/Disposable";
 import { PqSdkNugetPackageService } from "../common/PqSdkNugetPackageService";
 import { PqSdkOutputChannel } from "../features/PqSdkOutputChannel";
@@ -162,7 +162,7 @@ export class LifecycleCommands implements IDisposable {
 
     private intervalTaskHandler: NodeJS.Timeout | undefined;
     private activateIntervalTasks(): void {
-        // update lastCtimeOfMezFileWhoseInfoSeized once its info:static-type-check got re-eval
+        // update lastMtimeOfMezFileWhoseInfoSeized once its info:static-type-check got re-eval
         this.pqTestService.currentExtensionInfos.subscribe(() => {
             const currentPQTestExtensionFileLocation: string | undefined =
                 ExtensionConfigurations.DefaultExtensionLocation;
@@ -172,11 +172,11 @@ export class LifecycleCommands implements IDisposable {
                 : undefined;
 
             if (resolvedPQTestExtensionFileLocation && fs.existsSync(resolvedPQTestExtensionFileLocation)) {
-                this.lastCtimeOfMezFileWhoseInfoSeized = getCtimeOfAFile(resolvedPQTestExtensionFileLocation);
+                this.lastMtimeOfMezFileWhoseInfoSeized = getMtimeOfAFile(resolvedPQTestExtensionFileLocation);
 
                 this.outputChannel.appendInfoLine(
                     resolveI18nTemplate("PQSdk.lifecycle.command.update.lastCtimeOfMezFile", {
-                        lastCtimeOfMezFileWhoseInfoSeized: String(this.lastCtimeOfMezFileWhoseInfoSeized.getTime()),
+                        lastCtimeOfMezFileWhoseInfoSeized: String(this.lastMtimeOfMezFileWhoseInfoSeized.getTime()),
                     }),
                 );
             }
@@ -198,7 +198,7 @@ export class LifecycleCommands implements IDisposable {
     }
 
     private currentIncorrectConnectorPathInSettingGotPromptedBefore: boolean = false;
-    private lastCtimeOfMezFileWhoseInfoSeized: Date = new Date(0);
+    private lastMtimeOfMezFileWhoseInfoSeized: Date = new Date(0);
     private onGoingDisplayLatestExtensionInfoCommand:
         | {
               ctime: Date;
@@ -218,14 +218,14 @@ export class LifecycleCommands implements IDisposable {
             (!ExtensionConfigurations.featureUseServiceHost ||
                 (this.pqTestService as PqServiceHostClient).pqServiceHostConnected)
         ) {
-            const currentCtime: Date = getCtimeOfAFile(resolvedPQTestExtensionFileLocation);
+            const currentMtime: Date = getMtimeOfAFile(resolvedPQTestExtensionFileLocation);
 
-            if (currentCtime > this.lastCtimeOfMezFileWhoseInfoSeized && this.pqTestService.pqTestReady) {
+            if (currentMtime > this.lastMtimeOfMezFileWhoseInfoSeized && this.pqTestService.pqTestReady) {
                 // first check where we got an onGoing one or not,
                 // if the ongGoing one were newer or equaled to the current one, just return
                 if (
                     this.onGoingDisplayLatestExtensionInfoCommand &&
-                    this.onGoingDisplayLatestExtensionInfoCommand.ctime >= currentCtime
+                    this.onGoingDisplayLatestExtensionInfoCommand.ctime >= currentMtime
                 ) {
                     return;
                 }
@@ -233,17 +233,17 @@ export class LifecycleCommands implements IDisposable {
                 // we need to invoke a info task
                 this.outputChannel.appendInfoLine(
                     resolveI18nTemplate("PQSdk.lifecycle.command.detect.newerMezFile", {
-                        currentCtime: String(currentCtime.getTime()),
-                        diffCtime: String(currentCtime.getTime() - this.lastCtimeOfMezFileWhoseInfoSeized.getTime()),
+                        currentCtime: String(currentMtime.getTime()),
+                        diffCtime: String(currentMtime.getTime() - this.lastMtimeOfMezFileWhoseInfoSeized.getTime()),
                     }),
                 );
 
                 this.onGoingDisplayLatestExtensionInfoCommand = {
-                    ctime: currentCtime,
-                    deferred: this.displayLatestExtensionInfoCommand(currentCtime).finally(() => {
-                        if (this.onGoingDisplayLatestExtensionInfoCommand?.ctime === currentCtime) {
+                    ctime: currentMtime,
+                    deferred: this.displayLatestExtensionInfoCommand(currentMtime).finally(() => {
+                        if (this.onGoingDisplayLatestExtensionInfoCommand?.ctime === currentMtime) {
                             this.onGoingDisplayLatestExtensionInfoCommand = undefined;
-                            this.lastCtimeOfMezFileWhoseInfoSeized = currentCtime;
+                            this.lastMtimeOfMezFileWhoseInfoSeized = currentMtime;
                         }
                     }),
                 };

--- a/src/pqTestConnector/PqTestTaskUtils.ts
+++ b/src/pqTestConnector/PqTestTaskUtils.ts
@@ -10,7 +10,7 @@ import path from "path";
 import vscode from "vscode";
 
 import { getAnyMProjFilesBeneathTheFirstWorkspace, getFirstWorkspaceFolder } from "../utils/vscodes";
-import { getCtimeOfAFile, globFiles } from "../utils/files";
+import { getMtimeOfAFile, globFiles } from "../utils/files";
 import { ExtensionConfigurations } from "../constants/PowerQuerySdkConfiguration";
 import { findExecutable } from "../utils/executables";
 import { PowerQueryTaskProvider } from "../features/PowerQueryTaskProvider";
@@ -33,8 +33,8 @@ export async function executeBuildTaskAndAwaitIfNeeded(
         }
 
         if (currentlyAllMezFiles.length === 1) {
-            const theCtimeOfTheFile: Date = getCtimeOfAFile(currentlyAllMezFiles[0]);
-            needToRebuildBeforeEvaluation = theCtimeOfTheFile <= lastPqRelatedFileTouchedDate;
+            const theMtimeOfTheFile: Date = getMtimeOfAFile(currentlyAllMezFiles[0]);
+            needToRebuildBeforeEvaluation = theMtimeOfTheFile <= lastPqRelatedFileTouchedDate;
         } else {
             needToRebuildBeforeEvaluation = true;
         }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -54,11 +54,15 @@ export function tryRemoveDirectoryRecursively(directoryFullName: string): Promis
     });
 }
 
-export function getCtimeOfAFile(fileFullPath: string): Date {
+// The timestamp indicating the last time the file status was changed.
+export function getMtimeOfAFile(fileFullPath: string): Date {
     if (fs.existsSync(fileFullPath)) {
         const fileStats: fs.Stats = fs.statSync(fileFullPath);
 
-        return fileStats.ctime;
+        // ctime: The timestamp indicating the last time the file status was changed.
+        // mtime: The timestamp indicating the last time this file was modified.
+        // so we should use mtime over here.
+        return fileStats.mtime;
     }
 
     return new Date(0);


### PR DESCRIPTION
Fix the bug that we might constantly evaluate for connector info.

RCA: We previously compared ctime of a built mez file to tell whether we need to evaluate for info, ctime changed even everytime file properties got changed. We should use mtime insetead.

<img width="1233" alt="image" src="https://github.com/microsoft/vscode-powerquery-sdk/assets/69623692/5ac5ccf5-0bd6-4627-acff-64790e0a3344">

I manually tested against a new built mez or an updated mez, it worked flawlessly. This renaming pr should be pretty safe.




https://github.com/microsoft/vscode-powerquery-sdk/assets/69623692/57af1b0a-e973-4f97-8e5c-6af7063e0be2

