### PR TITLE
Flag tests that connect to external resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,6 +364,7 @@
         "lint": "eslint src --ext ts",
         "test": "npm run test:unit-test && npm run test:e2e",
         "test:unit-test": "mocha -r ts-node/register -s 0 \"./unit-tests/**/*.spec.ts\"",
+        "test:unit-test:no-external": "mocha -r ts-node/register -s 0 \"./unit-tests/**/*.spec.ts\" -i --fgrep \"[External]\"",
         "test:e2e": "npm run compile-tests && npm run test-ui",
         "vsix": "npx vsce package --target win32-x64",
         "code-install": "ts-node scripts/install.ts",

--- a/unit-tests/common/nuget/NugetCommandService.spec.ts
+++ b/unit-tests/common/nuget/NugetCommandService.spec.ts
@@ -12,13 +12,12 @@ import * as path from "path";
 import { findExecutable } from "../../../src/utils/executables";
 import { makeOneTmpDir } from "../../../src/utils/osUtils";
 import { NugetCommandService } from "../../../src/common/nuget/NugetCommandService";
+import { TestConstants } from "../testConstants";
 import { tryRemoveDirectoryRecursively } from "../../../src/utils/files";
 
 const expect = chai.expect;
-const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
-const InternalNugetFeed = "https://powerbi.pkgs.visualstudio.com/_packaging/PowerBiComponents/nuget/v3/index.json";
 
-describe("NugetCommandService unit tests", () => {
+describe(`${TestConstants.ExternalTestFlag} NugetCommandService unit tests`, () => {
     const nugetPath = findExecutable("nuget", [".exe", ""]);
 
     // disable these test cases for the ci due to auth config
@@ -34,8 +33,8 @@ describe("NugetCommandService unit tests", () => {
         it("getPackageReleasedVersions v1", async () => {
             const res = await nugetCommandService.getPackageReleasedVersions(
                 nugetPath,
-                InternalNugetFeed,
-                SdkPackageName,
+                TestConstants.InternalNugetFeed,
+                TestConstants.SdkPackageName,
             );
 
             expect(res.length).gt(1);
@@ -44,8 +43,8 @@ describe("NugetCommandService unit tests", () => {
         it("downloadAndExtractNugetPackage v1", async () => {
             const res = await nugetCommandService.getPackageReleasedVersions(
                 nugetPath,
-                InternalNugetFeed,
-                SdkPackageName,
+                TestConstants.InternalNugetFeed,
+                TestConstants.SdkPackageName,
             );
 
             expect(res.length).gt(1);
@@ -54,8 +53,8 @@ describe("NugetCommandService unit tests", () => {
 
             await nugetCommandService.downloadAndExtractNugetPackage(
                 nugetPath,
-                InternalNugetFeed,
-                SdkPackageName,
+                TestConstants.InternalNugetFeed,
+                TestConstants.SdkPackageName,
                 theVersionStr,
             );
 
@@ -64,7 +63,7 @@ describe("NugetCommandService unit tests", () => {
                     path.resolve(
                         oneTmpDir,
                         ".nuget",
-                        `${SdkPackageName}.${theVersionStr}`,
+                        `${TestConstants.SdkPackageName}.${theVersionStr}`,
                         `Microsoft.PowerQuery.SdkTools.${theVersionStr}.nupkg`,
                     ),
                 ),
@@ -72,7 +71,13 @@ describe("NugetCommandService unit tests", () => {
 
             expect(
                 fs.existsSync(
-                    path.resolve(oneTmpDir, ".nuget", `${SdkPackageName}.${theVersionStr}`, "tools", "PQTest.exe"),
+                    path.resolve(
+                        oneTmpDir,
+                        ".nuget",
+                        `${TestConstants.SdkPackageName}.${theVersionStr}`,
+                        "tools",
+                        "PQTest.exe",
+                    ),
                 ),
             ).true;
 

--- a/unit-tests/common/nuget/NugetHttpService.spec.ts
+++ b/unit-tests/common/nuget/NugetHttpService.spec.ts
@@ -13,29 +13,31 @@ import { makeOneTmpDir } from "../../../src/utils/osUtils";
 import { MAX_AWAIT_TIME } from "../../../src/test/common";
 import { NugetHttpService } from "../../../src/common/nuget/NugetHttpService";
 import { NugetVersions } from "../../../src/utils/NugetVersions";
-import { tryRemoveDirectoryRecursively } from "../../../src/utils/files";
 import { PqSdkTestOutputChannel } from "../../../src/test/utils/pqSdkTestOutputChannel";
+import { TestConstants } from "../testConstants";
+import { tryRemoveDirectoryRecursively } from "../../../src/utils/files";
 
 const expect = chai.expect;
-const SdkPackageName = "Microsoft.PowerQuery.SdkTools";
 
-describe("NugetHttpService unit tests", () => {
+describe(`${TestConstants.ExternalTestFlag} NugetHttpService unit tests`, () => {
     const testOutputChannel = new PqSdkTestOutputChannel();
     const nugetHttpService = new NugetHttpService(testOutputChannel);
 
     afterEach(() => testOutputChannel.emit());
 
     it("getPackageReleasedVersions v1", async () => {
-        const res = await nugetHttpService.getPackageReleasedVersions(SdkPackageName);
+        const res = await nugetHttpService.getPackageReleasedVersions(TestConstants.SdkPackageName);
         expect(res.versions.length).gt(1);
     }).timeout(MAX_AWAIT_TIME);
 
     it("getSortedPackageReleasedVersions v1", async () => {
-        const allVersions: NugetVersions[] = await nugetHttpService.getSortedPackageReleasedVersions(SdkPackageName);
+        const allVersions: NugetVersions[] = await nugetHttpService.getSortedPackageReleasedVersions(
+            TestConstants.SdkPackageName,
+        );
         expect(allVersions.length).gt(1);
 
         const _2_110_Versions: NugetVersions[] = await nugetHttpService.getSortedPackageReleasedVersions(
-            SdkPackageName,
+            TestConstants.SdkPackageName,
             {
                 maximumNugetVersion: NugetVersions.createFromFuzzyVersionString("2.110.x"),
             },
@@ -49,10 +51,10 @@ describe("NugetHttpService unit tests", () => {
 
     it("downloadAndExtractNugetPackage v1", async () => {
         const oneTmpDir = makeOneTmpDir();
-        const res = await nugetHttpService.getPackageReleasedVersions(SdkPackageName);
+        const res = await nugetHttpService.getPackageReleasedVersions(TestConstants.SdkPackageName);
         expect(res.versions.length).gt(1);
         const theVersion = res.versions[res.versions.length - 1];
-        await nugetHttpService.downloadAndExtractNugetPackage(SdkPackageName, theVersion, oneTmpDir);
+        await nugetHttpService.downloadAndExtractNugetPackage(TestConstants.SdkPackageName, theVersion, oneTmpDir);
 
         expect(fs.existsSync(path.resolve(oneTmpDir, "Microsoft.PowerQuery.SdkTools.nuspec"))).true;
         expect(fs.existsSync(path.resolve(oneTmpDir, "tools", "PQTest.exe"))).true;

--- a/unit-tests/common/testConstants.ts
+++ b/unit-tests/common/testConstants.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+export enum TestConstants {
+    ExternalTestFlag = "[External]",
+    SdkPackageName = "Microsoft.PowerQuery.SdkTools",
+    InternalNugetFeed = "https://powerbi.pkgs.visualstudio.com/_packaging/PowerBiComponents/nuget/v3/index.json",
+}


### PR DESCRIPTION
In certain build environments we want to be able to exclude tests that make external connections. This changes adds an `[External]` prefix to the two test suites that make external connections, and uses the `-i --fgrep` mocha CLI options to exclude these tests. 