### PR TITLE
Update vsce package script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,10 +2557,11 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
                 "@vscode/debugadapter": "^1.65.0",
                 "@vscode/debugadapter-testsupport": "^1.65.0",
                 "@vscode/test-electron": "^2.4.1",
-                "@vscode/vsce": "^3.2.0",
                 "chai": "^4.4.1",
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^8.10.0",
@@ -1088,48 +1087,6 @@
             },
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/@vscode/vsce": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.2.0.tgz",
-            "integrity": "sha512-c/AId5Lp50HTszCBDfXfD/Go2djm6qO/WfedP2Y3BpRP+V+ttr8T0mTvZ8WEyTiBp2EfrYnzYUCx0ocB9mHy4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@azure/identity": "^4.1.0",
-                "@vscode/vsce-sign": "^2.0.0",
-                "azure-devops-node-api": "^12.5.0",
-                "chalk": "^2.4.2",
-                "cheerio": "^1.0.0-rc.9",
-                "cockatiel": "^3.1.2",
-                "commander": "^6.2.1",
-                "form-data": "^4.0.0",
-                "glob": "^11.0.0",
-                "hosted-git-info": "^4.0.2",
-                "jsonc-parser": "^3.2.0",
-                "leven": "^3.1.0",
-                "markdown-it": "^14.1.0",
-                "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
-                "parse-semver": "^1.1.1",
-                "read": "^1.0.7",
-                "semver": "^7.5.2",
-                "tmp": "^0.2.3",
-                "typed-rest-client": "^1.8.4",
-                "url-join": "^4.0.1",
-                "xml2js": "^0.5.0",
-                "yauzl": "^2.3.1",
-                "yazl": "^2.2.2"
-            },
-            "bin": {
-                "vsce": "vsce"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "optionalDependencies": {
-                "keytar": "^7.7.0"
             }
         },
         "node_modules/@vscode/vsce-sign": {
@@ -2515,15 +2472,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/commander": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/compare-versions": {
@@ -4915,16 +4863,6 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
-        "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
         "node_modules/lint-staged": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
@@ -5445,24 +5383,6 @@
             "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
             "dev": true
         },
-        "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
         "node_modules/md5": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -5474,13 +5394,6 @@
                 "crypt": "0.0.2",
                 "is-buffer": "~1.1.6"
             }
-        },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -6686,16 +6599,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -8350,13 +8253,6 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/underscore": {
             "version": "1.13.7",

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
         "test:unit-test": "mocha -r ts-node/register -s 0 \"./unit-tests/**/*.spec.ts\" --reporter mocha-multi-reporters --reporter-options configFile=mochaReporterConfig.json",
         "test:unit-test:no-external": "mocha -r ts-node/register -s 0 \"./unit-tests/**/*.spec.ts\" -i --fgrep \"[External]\" --reporter mocha-multi-reporters --reporter-options configFile=mochaReporterConfig.json",
         "test-ui": "node ./out/src/test/runTest.js",
-        "vsix": "npx vsce package --target win32-x64",
+        "vsix": "npx @vscode/vsce@latest package --target win32-x64",
         "vscode:prepublish": "npm run package",
         "watch": "webpack --mode development --watch",
         "watch-tests": "rimraf out && tsc -p . -w --outDir out"
@@ -388,7 +388,6 @@
         "@vscode/debugadapter": "^1.65.0",
         "@vscode/debugadapter-testsupport": "^1.65.0",
         "@vscode/test-electron": "^2.4.1",
-        "@vscode/vsce": "^3.2.0",
         "chai": "^4.4.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^8.10.0",

--- a/webviews/pq-test-result-view/package-lock.json
+++ b/webviews/pq-test-result-view/package-lock.json
@@ -56,7 +56,7 @@
                 "webpack-merge": "^5.10.0"
             },
             "engines": {
-                "node": ">=18.17.0"
+                "node": ">=20"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -4865,10 +4865,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -7543,10 +7544,11 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-            "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",


### PR DESCRIPTION
- npm audit fix
- removed reference to `vsce`
- use `@vscode/vsce@latest` to ensure we're using latest packaging tools