### PR TITLE
fix: include parameterquery.pq files in set credential query file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to the "vscode-powerquery-sdk" extension will be documented 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## v0.6.2
+## v0.7.2
 
-<TODO>
+- Fixed: `*.parameterquery.pq` files now appear in the set credential query file picker, prioritized above other query files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-powerquery-sdk",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-powerquery-sdk",
-            "version": "0.7.1",
+            "version": "0.7.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-powerquery-sdk",
     "displayName": "Power Query SDK",
     "description": "Power Query Connector SDK",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "author": "Microsoft Corporation",
     "license": "MIT",
     "homepage": "https://github.com/microsoft/vscode-powerquery-sdk#readme",

--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -37,6 +37,7 @@ import { extensionI18n, resolveI18nTemplate } from "../i18n/extension";
 import { PqTestResultViewPanel, SimplePqTestResultViewBroker } from "../panels/PqTestResultViewPanel";
 import { PqServiceHostClient } from "../pqTestConnector/PqServiceHostClient";
 import { debounce } from "../utils/debounce";
+import { connectorQueryFileExcludeGlob, connectorQueryFileGlob, parameterQueryFirstCompare } from "../utils/connectorQueryFiles";
 import { getMtimeOfAFile } from "../utils/files";
 import { prettifyJson, resolveTemplateSubstitutedValues } from "../utils/strings";
 import {
@@ -1100,21 +1101,13 @@ export class LifecycleCommands implements IDisposable {
                     });
 
                     const connectorQueryFiles: vscode.Uri[] = await vscode.workspace.findFiles(
-                        "**/*.{query,test,parameterquery}.pq",
-                        "**/{bin,obj}/**",
+                        connectorQueryFileGlob,
+                        connectorQueryFileExcludeGlob,
                         1e2,
                     );
 
                     // Prioritize parameterquery files before query/test files in the picker
-                    connectorQueryFiles.sort((a: vscode.Uri, b: vscode.Uri): number => {
-                        const aIsParameterQuery: boolean = a.fsPath.endsWith(".parameterquery.pq");
-                        const bIsParameterQuery: boolean = b.fsPath.endsWith(".parameterquery.pq");
-
-                        if (aIsParameterQuery && !bIsParameterQuery) return -1;
-                        if (!aIsParameterQuery && bIsParameterQuery) return 1;
-
-                        return a.fsPath.localeCompare(b.fsPath);
-                    });
+                    connectorQueryFiles.sort(parameterQueryFirstCompare);
 
                     async function collectInputs(): Promise<CreateAuthState> {
                         const state: Partial<CreateAuthState> = {} as Partial<CreateAuthState>;

--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -36,8 +36,12 @@ import { GlobalEventBus, GlobalEvents } from "../GlobalEventBus";
 import { extensionI18n, resolveI18nTemplate } from "../i18n/extension";
 import { PqTestResultViewPanel, SimplePqTestResultViewBroker } from "../panels/PqTestResultViewPanel";
 import { PqServiceHostClient } from "../pqTestConnector/PqServiceHostClient";
+import {
+    connectorQueryFileExcludeGlob,
+    connectorQueryFileGlob,
+    parameterQueryFirstCompare,
+} from "../utils/connectorQueryFiles";
 import { debounce } from "../utils/debounce";
-import { connectorQueryFileExcludeGlob, connectorQueryFileGlob, parameterQueryFirstCompare } from "../utils/connectorQueryFiles";
 import { getMtimeOfAFile } from "../utils/files";
 import { prettifyJson, resolveTemplateSubstitutedValues } from "../utils/strings";
 import {

--- a/src/commands/LifecycleCommands.ts
+++ b/src/commands/LifecycleCommands.ts
@@ -1100,10 +1100,21 @@ export class LifecycleCommands implements IDisposable {
                     });
 
                     const connectorQueryFiles: vscode.Uri[] = await vscode.workspace.findFiles(
-                        "**/*.{query,test}.pq",
+                        "**/*.{query,test,parameterquery}.pq",
                         "**/{bin,obj}/**",
                         1e2,
                     );
+
+                    // Prioritize parameterquery files before query/test files in the picker
+                    connectorQueryFiles.sort((a: vscode.Uri, b: vscode.Uri): number => {
+                        const aIsParameterQuery: boolean = a.fsPath.endsWith(".parameterquery.pq");
+                        const bIsParameterQuery: boolean = b.fsPath.endsWith(".parameterquery.pq");
+
+                        if (aIsParameterQuery && !bIsParameterQuery) return -1;
+                        if (!aIsParameterQuery && bIsParameterQuery) return 1;
+
+                        return a.fsPath.localeCompare(b.fsPath);
+                    });
 
                     async function collectInputs(): Promise<CreateAuthState> {
                         const state: Partial<CreateAuthState> = {} as Partial<CreateAuthState>;

--- a/src/test/suite/queryFilePicker.test.ts
+++ b/src/test/suite/queryFilePicker.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { connectorQueryFileExcludeGlob, connectorQueryFileGlob, parameterQueryFirstCompare } from "../../utils/connectorQueryFiles";
+import { ensureRequiredExtensionsAreLoaded } from "../TestUtils";
+
+suite("Query File Picker Integration Tests", () => {
+    suiteSetup(ensureRequiredExtensionsAreLoaded);
+
+    test("should discover .parameterquery.pq files alongside .query.pq and .test.pq", async () => {
+        const files: vscode.Uri[] = await vscode.workspace.findFiles(
+            connectorQueryFileGlob,
+            connectorQueryFileExcludeGlob,
+            1e2,
+        );
+
+        const filenames: string[] = files.map((uri: vscode.Uri) => path.basename(uri.fsPath));
+
+        assert.ok(
+            filenames.some((name: string) => name.endsWith(".query.pq")),
+            "Should find .query.pq files",
+        );
+
+        assert.ok(
+            filenames.some((name: string) => name.endsWith(".test.pq")),
+            "Should find .test.pq files",
+        );
+
+        assert.ok(
+            filenames.some((name: string) => name.endsWith(".parameterquery.pq")),
+            "Should find .parameterquery.pq files",
+        );
+    });
+
+    test("should sort parameterquery files before other query files", async () => {
+        const files: vscode.Uri[] = await vscode.workspace.findFiles(
+            connectorQueryFileGlob,
+            connectorQueryFileExcludeGlob,
+            1e2,
+        );
+
+        files.sort(parameterQueryFirstCompare);
+
+        const lastParameterQueryIndex: number = files.map((f: vscode.Uri) =>
+            f.fsPath.endsWith(".parameterquery.pq"),
+        ).lastIndexOf(true);
+
+        const firstNonParameterQueryIndex: number = files.findIndex(
+            (f: vscode.Uri) => !f.fsPath.endsWith(".parameterquery.pq"),
+        );
+
+        if (lastParameterQueryIndex !== -1 && firstNonParameterQueryIndex !== -1) {
+            assert.ok(
+                lastParameterQueryIndex < firstNonParameterQueryIndex,
+                `All .parameterquery.pq files should appear before other query files. ` +
+                `Last parameterquery at index ${lastParameterQueryIndex}, first other at index ${firstNonParameterQueryIndex}`,
+            );
+        }
+    });
+
+    test("should maintain alphabetical order within each group", async () => {
+        const files: vscode.Uri[] = await vscode.workspace.findFiles(
+            connectorQueryFileGlob,
+            connectorQueryFileExcludeGlob,
+            1e2,
+        );
+
+        files.sort(parameterQueryFirstCompare);
+
+        const parameterQueryFiles: string[] = files
+            .filter((f: vscode.Uri) => f.fsPath.endsWith(".parameterquery.pq"))
+            .map((f: vscode.Uri) => f.fsPath);
+
+        const otherFiles: string[] = files
+            .filter((f: vscode.Uri) => !f.fsPath.endsWith(".parameterquery.pq"))
+            .map((f: vscode.Uri) => f.fsPath);
+
+        for (let i: number = 1; i < parameterQueryFiles.length; i++) {
+            assert.ok(
+                parameterQueryFiles[i - 1].localeCompare(parameterQueryFiles[i]) <= 0,
+                `Parameterquery files should be alphabetical: ${parameterQueryFiles[i - 1]} should come before ${parameterQueryFiles[i]}`,
+            );
+        }
+
+        for (let i: number = 1; i < otherFiles.length; i++) {
+            assert.ok(
+                otherFiles[i - 1].localeCompare(otherFiles[i]) <= 0,
+                `Other query files should be alphabetical: ${otherFiles[i - 1]} should come before ${otherFiles[i]}`,
+            );
+        }
+    });
+});

--- a/src/test/suite/queryFilePicker.test.ts
+++ b/src/test/suite/queryFilePicker.test.ts
@@ -9,7 +9,11 @@ import * as assert from "assert";
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { connectorQueryFileExcludeGlob, connectorQueryFileGlob, parameterQueryFirstCompare } from "../../utils/connectorQueryFiles";
+import {
+    connectorQueryFileExcludeGlob,
+    connectorQueryFileGlob,
+    parameterQueryFirstCompare,
+} from "../../utils/connectorQueryFiles";
 import { ensureRequiredExtensionsAreLoaded } from "../TestUtils";
 
 suite("Query File Picker Integration Tests", () => {
@@ -49,9 +53,9 @@ suite("Query File Picker Integration Tests", () => {
 
         files.sort(parameterQueryFirstCompare);
 
-        const lastParameterQueryIndex: number = files.map((f: vscode.Uri) =>
-            f.fsPath.endsWith(".parameterquery.pq"),
-        ).lastIndexOf(true);
+        const lastParameterQueryIndex: number = files
+            .map((f: vscode.Uri) => f.fsPath.endsWith(".parameterquery.pq"))
+            .lastIndexOf(true);
 
         const firstNonParameterQueryIndex: number = files.findIndex(
             (f: vscode.Uri) => !f.fsPath.endsWith(".parameterquery.pq"),
@@ -61,7 +65,7 @@ suite("Query File Picker Integration Tests", () => {
             assert.ok(
                 lastParameterQueryIndex < firstNonParameterQueryIndex,
                 `All .parameterquery.pq files should appear before other query files. ` +
-                `Last parameterquery at index ${lastParameterQueryIndex}, first other at index ${firstNonParameterQueryIndex}`,
+                    `Last parameterquery at index ${lastParameterQueryIndex}, first other at index ${firstNonParameterQueryIndex}`,
             );
         }
     });

--- a/src/test/testFixture/TestConnector.test.pq
+++ b/src/test/testFixture/TestConnector.test.pq
@@ -1,0 +1,11 @@
+// Test file for integration tests
+let
+    Fact = (description as text, expected, actual) =>
+        [description = description, expected = expected, actual = actual, passed = expected = actual],
+
+    facts = {
+        Fact("List has expected count", 5, List.Count({1, 2, 3, 4, 5})),
+        Fact("FirstN returns correct result", {1}, List.FirstN({1, 2, 3}, 1))
+    }
+in
+    facts

--- a/src/test/testFixture/TestConnectorA.parameterquery.pq
+++ b/src/test/testFixture/TestConnectorA.parameterquery.pq
@@ -1,0 +1,5 @@
+// Parameter query file for integration tests
+let
+    source = {1, 2, 3, 4, 5}
+in
+    [data = source]

--- a/src/test/testFixture/TestConnectorA.query.pq
+++ b/src/test/testFixture/TestConnectorA.query.pq
@@ -1,0 +1,6 @@
+// Test query file for integration tests
+(parameter) =>
+let
+    result = List.FirstN(parameter[data], 1)
+in
+    result

--- a/src/test/testFixture/TestConnectorB.parameterquery.pq
+++ b/src/test/testFixture/TestConnectorB.parameterquery.pq
@@ -1,0 +1,5 @@
+// Parameter query file for integration tests
+let
+    source = {1, 2, 3, 4, 5}
+in
+    [data = source]

--- a/src/test/testFixture/TestConnectorB.query.pq
+++ b/src/test/testFixture/TestConnectorB.query.pq
@@ -1,0 +1,6 @@
+// Test query file for integration tests
+(parameter) =>
+let
+    result = List.FirstN(parameter[data], 1)
+in
+    result

--- a/src/utils/connectorQueryFiles.ts
+++ b/src/utils/connectorQueryFiles.ts
@@ -17,6 +17,7 @@ export function parameterQueryFirstCompare(a: vscode.Uri, b: vscode.Uri): number
     const bIsPQ: boolean = b.fsPath.endsWith(".parameterquery.pq");
 
     if (aIsPQ && !bIsPQ) return -1;
+
     if (!aIsPQ && bIsPQ) return 1;
 
     return a.fsPath.localeCompare(b.fsPath);

--- a/src/utils/connectorQueryFiles.ts
+++ b/src/utils/connectorQueryFiles.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the MIT license found in the
+ * LICENSE file in the root of this projects source tree.
+ */
+
+import * as vscode from "vscode";
+
+export const connectorQueryFileGlob: string = "**/*.{query,test,parameterquery}.pq";
+export const connectorQueryFileExcludeGlob: string = "**/{bin,obj}/**";
+
+// Comparator that sorts `.parameterquery.pq` files before other query files,
+// with alphabetical ordering within each group.
+export function parameterQueryFirstCompare(a: vscode.Uri, b: vscode.Uri): number {
+    const aIsPQ: boolean = a.fsPath.endsWith(".parameterquery.pq");
+    const bIsPQ: boolean = b.fsPath.endsWith(".parameterquery.pq");
+
+    if (aIsPQ && !bIsPQ) return -1;
+    if (!aIsPQ && bIsPQ) return 1;
+
+    return a.fsPath.localeCompare(b.fsPath);
+}


### PR DESCRIPTION
## Problem

`*.parameterquery.pq` files contain data source information required for setting credentials, but they were excluded from the "Set Credential" command's query file picker. The glob pattern `**/*.{query,test}.pq` only matched `.query.pq` and `.test.pq` files.

## Changes

- Updated the `findFiles` glob in `generateAndSetCredentialCommandV2()` to `**/*.{query,test,parameterquery}.pq`
- Added sort logic to prioritize `.parameterquery.pq` files at the top of the picker list

## Testing

- Verified `*.parameterquery.pq` files appear in the Step 2 query file picker
- Verified `.parameterquery.pq` files are listed before `.query.pq` and `.test.pq` files